### PR TITLE
CR quota

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -41,5 +41,6 @@ kind: Kustomization
 resources:
 - ../crd
 - ../manager
+- ../quota
 - ../rbac
 - ../storage

--- a/config/quota/config-limit.yaml
+++ b/config/quota/config-limit.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: kokumetricsconfig-limit
+spec:
+  hard:
+    count/kokumetricsconfigs.koku-metrics-cfg.openshift.io: 1

--- a/config/quota/kustomization.yaml
+++ b/config/quota/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- config-limit.yaml

--- a/controllers/kokumetricsconfig_controller.go
+++ b/controllers/kokumetricsconfig_controller.go
@@ -496,9 +496,11 @@ func (r *KokuMetricsConfigReconciler) Reconcile(req ctrl.Request) (ctrl.Result, 
 
 	// delete CR outside of koku-metrics-operator namespace
 	if kmCfg.ObjectMeta.Namespace != kokuMetricsNamespace {
-		msg := fmt.Sprintf("Deleting CR `%s` because it is outside of `%s` namespace", kmCfg.ObjectMeta.Name, kokuMetricsNamespace)
+		msg := fmt.Sprintf("deleting CR `%s` because it is outside of `%s` namespace", kmCfg.ObjectMeta.Name, kokuMetricsNamespace)
 		log.Info(msg)
-		r.Delete(context.Background(), kmCfg)
+		if err := r.Delete(context.Background(), kmCfg); err != nil {
+			log.Info(fmt.Sprintf("delete error: %v", err)) // simply log the error, and reconcile again
+		}
 		return ctrl.Result{}, nil
 	}
 

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -64,12 +65,15 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
+	namespaces := []string{"koku-metrics-operator", "openshift-config"} // List of Namespaces
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
 		Port:               9443,
 		LeaderElection:     enableLeaderElection,
 		LeaderElectionID:   "91c624a5.openshift.io",
+		NewCache:           cache.MultiNamespacedCacheBuilder(namespaces),
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
This PR adds:
- deletion of any `KokuMetricsConfig` that are outside of the `koku-metrics-operator` namespace.
- a `ResourceQuota` so that only 1 `KokuMetricsConfig` CR can exist in `koku-metrics-operator` namespace at any one time.