### PR TITLE
COST-1008 - add proxy config to http transport

### DIFF
--- a/crhchttp/http_cloud_dot_redhat.go
+++ b/crhchttp/http_cloud_dot_redhat.go
@@ -120,6 +120,7 @@ func SetupRequest(authConfig *AuthConfig, contentType, method, uri string, body 
 // GetClient Return client with certificate handling based on configuration
 func GetClient(authConfig *AuthConfig) HTTPClient {
 	log := authConfig.Log.WithValues("kokumetricsconfig", "GetClient")
+	transport := &http.Transport{Proxy: http.ProxyFromEnvironment}
 	if authConfig.ValidateCert {
 		// create the client specifying the ca cert file for transport
 		caCert, err := ioutil.ReadFile(cacerts)
@@ -129,15 +130,10 @@ func GetClient(authConfig *AuthConfig) HTTPClient {
 		caCertPool := x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM(caCert)
 
-		transport := &http.Transport{TLSClientConfig: &tls.Config{RootCAs: caCertPool}}
-		return &http.Client{
-			Timeout:   30 * time.Second,
-			Transport: transport,
-		}
+		transport.TLSClientConfig = &tls.Config{RootCAs: caCertPool}
 	}
-	log.Info("configured to not using the certificate for this request")
 	// Default the client
-	return &http.Client{Timeout: 30 * time.Second}
+	return &http.Client{Timeout: 30 * time.Second, Transport: transport}
 }
 
 // ProcessResponse Log response for request and return valid


### PR DESCRIPTION
Implements an HTTP transport that uses a Proxy. The transport grabs the proxy info from the environment.

OLM should handle cluster-wide Proxy for us by adding `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` to the Pod environment. See [here](https://docs.openshift.com/container-platform/4.6/operators/admin/olm-configuring-proxy-support.html#olm-overriding-proxy-settings_olm-configuring-proxy-support).
