### PR TITLE
COST-1259 - bump prometheus query timeout to 90 seconds

### DIFF
--- a/collector/prometheus.go
+++ b/collector/prometheus.go
@@ -196,7 +196,7 @@ func (c *PromCollector) GetPromConn(kmCfg *kokumetricscfgv1beta1.KokuMetricsConf
 func (c *PromCollector) getQueryResults(queries *querys, results *mappedResults) error {
 	log := c.Log.WithValues("kokumetricsconfig", "getQueryResults")
 	for _, query := range *queries {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 		defer cancel()
 
 		queryResult, warnings, err := c.PromConn.QueryRange(ctx, query.QueryString, *c.TimeSeries)


### PR DESCRIPTION
We run 19 total queries. With a timeout set to 90 seconds, at worst, these will consume 29 minutes. If we are still timing out after 90 seconds, then we will need a different solution for our queries.