### PR TITLE
update source creation steps

### DIFF
--- a/docs/csv-description.md
+++ b/docs/csv-description.md
@@ -190,16 +190,17 @@ If the `koku-metrics-operator` is configured to run in a restricted network, the
 ## Create a source
 In a restricted network, the `koku-metrics-operator` cannot automatically create a source. This process must be done manually. In the cloud.redhat.com platform, open the [Sources menu](https://cloud.redhat.com/settings/sources/) to begin adding an OpenShift source to cost management:
 
+Prerequisites:
+* The cluster identifier which can be found in the KokuMetricsConfig CR, the cluster Overview page, or the cluster Help > About.
+
+Create source:
 1. Navigate to the Sources menu
 2. Select the `Red Hat sources` tab
-3. Click `Add source` to open the Sources wizard.
-4. Enter a name for the source and click `Next`.
-5. Select `Red Hat Openshift Container Platform` as the source type and Cost Management as the application. Click `Next`.
-6. Enter the cluster identifier into the cloud.redhat.com Sources wizard, and click `Next`.
-
-    **Note:** The cluster identifier can be found in the KokuMetricsConfig CR, the cluster Overview page, or the cluster Help > About.
-
-7. In the cloud.redhat.com Sources wizard, review the details and click `Finish` to create the Source.
+3. Create a new `Red Hat Openshift Container Platform` source:
+    * give the source a unique name
+    * add the Cost Management application
+    * add the cluster identifier
+4. In the Sources wizard, review the details and click `Finish` to create the Source.
 
 ## Upload the reports to cost managment
 Uploading reports to cost managment is done through curl:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,42 @@
+# Frequently asked questions
+
+## Our operator is stuck upgrading from v0.9.4 to v0.9.5. How can we force the upgrade?
+
+1. Log into the cluster via the CLI
+2. Update the KokuMetricsConfig from v1alpha1 to v1beta1
+    ```
+    $ oc get kokumetricsconfigs (this step is to get the name of the CR. If you know it, this step can be skipped)
+    NAME                    AGE
+    kokumetricscfg-sample   41m
+    $ oc get kokumetricsconfigs kokumetricscfg-sample -o json > tmp.json
+    $ head -3 tmp.json
+    {
+    "apiVersion": "koku-metrics-cfg.openshift.io/v1beta1", <--------- ensure that this says `v1beta1`. Update if needed.
+    "kind": "KokuMetricsConfig",
+    $ oc apply -f tmp.json
+    Warning: oc apply should be used on resource created by either oc create --save-config or oc apply
+    kokumetricsconfig.koku-metrics-cfg.openshift.io/kokumetricscfg-sample configured
+    ```
+    **Note**: apply the tmp.json even if you did not make changes to the file.
+
+3. Verify that the KokuMetricsConfig CustomResourceDefinition contains the v1alpha1 and v1beta1 in the storedVersions status:
+    ```
+    $ oc get crd kokumetricsconfigs.koku-metrics-cfg.openshift.io -o jsonpath='{.status.storedVersions}{"\n"}'
+    [v1alpha1 v1beta1]
+    ```
+4. In a second terminal window, open a proxy to the cluster (you can choose any open port number):
+    ```
+    $ oc proxy --port=9000
+    Starting to serve on 127.0.0.1:9000
+    ```
+5. Back in the first terminal, update the status of the CRD to remove the v1alpha1:
+    ```
+    $ curl -X PATCH -H 'Content-Type: application/strategic-merge-patch+json' --data '{"status":{"storedVersions":["v1beta1"]}}' localhost:9000/apis/apiextensions.k8s.io/v1/customresourcedefinitions/kokumetricsconfigs.koku-metrics-cfg.openshift.io/status
+    ```
+6. Verify that the CRD status only contains v1beta1:
+    ```
+    $ oc get crd kokumetricsconfigs.koku-metrics-cfg.openshift.io -o jsonpath='{.status.storedVersions}{"\n"}'
+    [v1beta1]
+    ```
+7. Uninstall the operator and reinstall from OperatorHub. This should be installed in the same namespace in which it was previously installed. Ensure that the old CR appears under KokuMetricsConfigs.
+8. Close the proxy to the cluster.


### PR DESCRIPTION
1. make the source creation docs a little more generic. The sources wizard should be the real guide, not the docs here.
2. added a `faqs` doc. Includes steps for forcing v0.9.4 -> v0.9.5 upgrade.