### PR TITLE
COST-1287 - update queries for kube-state-metrics v2 release

### DIFF
--- a/collector/queries.go
+++ b/collector/queries.go
@@ -141,7 +141,7 @@ var (
 	podQueries = &querys{
 		query{
 			Name:        "pod-limit-cpu-cores",
-			QueryString: "sum(kube_pod_container_resource_limits_cpu_cores) by (pod, namespace, node)",
+			QueryString: "sum(kube_pod_container_resource_limits{resource='cpu'}) by (pod, namespace, node)",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-limit-cpu-cores",
@@ -153,7 +153,7 @@ var (
 		},
 		query{
 			Name:        "pod-limit-memory-bytes",
-			QueryString: "sum(kube_pod_container_resource_limits_memory_bytes) by (pod, namespace, node)",
+			QueryString: "sum(kube_pod_container_resource_limits{resource='memory'}) by (pod, namespace, node)",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-limit-memory-bytes",
@@ -165,7 +165,7 @@ var (
 		},
 		query{
 			Name:        "pod-request-cpu-cores",
-			QueryString: "sum(kube_pod_container_resource_requests_cpu_cores) by (pod, namespace, node)",
+			QueryString: "sum(kube_pod_container_resource_requests{resource='cpu'}) by (pod, namespace, node)",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-request-cpu-cores",
@@ -177,7 +177,7 @@ var (
 		},
 		query{
 			Name:        "pod-request-memory-bytes",
-			QueryString: "sum(kube_pod_container_resource_requests_memory_bytes) by (pod, namespace, node)",
+			QueryString: "sum(kube_pod_container_resource_requests{resource='memory'}) by (pod, namespace, node)",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-request-memory-bytes",

--- a/collector/queries.go
+++ b/collector/queries.go
@@ -30,7 +30,7 @@ var (
 	nodeQueries = &querys{
 		query{
 			Name:        "node-allocatable-cpu-cores",
-			QueryString: "kube_node_status_allocatable_cpu_cores * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)",
+			QueryString: "kube_node_status_allocatable{resource='cpu'} * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)",
 			MetricKey:   staticFields{"node": "node", "provider_id": "provider_id"},
 			QueryValue: &saveQueryValue{
 				ValName:         "node-allocatable-cpu-cores",
@@ -42,7 +42,7 @@ var (
 		},
 		query{
 			Name:        "node-allocatable-memory-bytes",
-			QueryString: "kube_node_status_allocatable_memory_bytes * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)",
+			QueryString: "kube_node_status_allocatable{resource='memory'} * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)",
 			MetricKey:   staticFields{"node": "node", "provider_id": "provider_id"},
 			QueryValue: &saveQueryValue{
 				ValName:         "node-allocatable-memory-bytes",
@@ -54,7 +54,7 @@ var (
 		},
 		query{
 			Name:        "node-capacity-cpu-cores",
-			QueryString: "kube_node_status_capacity_cpu_cores * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)",
+			QueryString: "kube_node_status_capacity{resource='cpu'} * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)",
 			MetricKey:   staticFields{"node": "node", "provider_id": "provider_id"},
 			QueryValue: &saveQueryValue{
 				ValName:         "node-capacity-cpu-cores",
@@ -66,7 +66,7 @@ var (
 		},
 		query{
 			Name:        "node-capacity-memory-bytes",
-			QueryString: "kube_node_status_capacity_memory_bytes * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)",
+			QueryString: "kube_node_status_capacity{resource='memory'} * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)",
 			MetricKey:   staticFields{"node": "node", "provider_id": "provider_id"},
 			QueryValue: &saveQueryValue{
 				ValName:         "node-capacity-memory-bytes",


### PR DESCRIPTION
This PR replaces some deprecated [kube-state-metrics that were removed in v2.0](https://kubernetes.io/blog/2021/04/13/kube-state-metrics-v-2-0/).

testing:
The following files should match exactly.
[new-query-results.csv](https://github.com/project-koku/koku-metrics-operator/files/6305350/e84cc634-acae-4e78-ab19-dff18d7dc673_openshift_usage_report_sorted.2.csv)
[old-query-results.csv](https://github.com/project-koku/koku-metrics-operator/files/6305355/7d3b6e1c-14d9-48a6-9ee2-90f419cab016_openshift_usage_report_sorted.2.csv)