### PR TITLE
COST1303/1260 add cr status and meta to manifest

### DIFF
--- a/api/v1beta1/kokumetricsconfig_types.go
+++ b/api/v1beta1/kokumetricsconfig_types.go
@@ -208,6 +208,11 @@ type KokuMetricsConfigSpec struct {
 	// +optional
 	ClusterID string `json:"clusterID,omitempty"`
 
+	// ClusterVersion is a field of KokuMetricsConfig to represent the cluster version. Normally this value should not be
+	// specified. Only set this value if the clusterVersion cannot be obtained from the ClusterVersion.
+	// +optional
+	ClusterVersion string `json:"clusterVersion,omitempty"`
+
 	// FOR DEVELOPMENT ONLY.
 	// APIURL is a field of KokuMetricsConfig to represent the url of the API endpoint for service interaction.
 	// The default is `https://cloud.redhat.com`.
@@ -420,6 +425,9 @@ type KokuMetricsConfigStatus struct {
 
 	// ClusterID is a field of KokuMetricsConfig to represent the cluster UUID.
 	ClusterID string `json:"clusterID,omitempty"`
+
+	// ClusterVersion is a field of KokuMetricsConfig to represent the cluster version.
+	ClusterVersion string `json:"clusterVersion,omitempty"`
 
 	// APIURL is a field of KokuMetricsConfig to represent the url of the API endpoint for service interaction.
 	// +optional

--- a/config/crd/bases/koku-metrics-cfg.openshift.io_kokumetricsconfigs.yaml
+++ b/config/crd/bases/koku-metrics-cfg.openshift.io_kokumetricsconfigs.yaml
@@ -70,6 +70,12 @@ spec:
                   the cluster UUID. Normally this value should not be specified. Only
                   set this value if the clusterID cannot be obtained from the ClusterVersion.
                 type: string
+              clusterVersion:
+                description: ClusterVersion is a field of KokuMetricsConfig to represent
+                  the cluster version. Normally this value should not be specified.
+                  Only set this value if the clusterVersion cannot be obtained from
+                  the ClusterVersion.
+                type: string
               packaging:
                 description: Packaging is a field of KokuMetricsConfig to represent
                   the packaging object.
@@ -416,6 +422,10 @@ spec:
               clusterID:
                 description: ClusterID is a field of KokuMetricsConfig to represent
                   the cluster UUID.
+                type: string
+              clusterVersion:
+                description: ClusterVersion is a field of KokuMetricsConfig to represent
+                  the cluster version.
                 type: string
               operator_commit:
                 description: OperatorCommit is a field of KokuMetricsConfig that shows

--- a/controllers/kokumetricsconfig_controller.go
+++ b/controllers/kokumetricsconfig_controller.go
@@ -164,7 +164,7 @@ func GetClientset() (*kubernetes.Clientset, error) {
 	return clientset, nil
 }
 
-// GetClusterID Collects the cluster identifier from the Cluster Version custom resource object
+// GetClusterID Collects the cluster identifier and version from the Cluster Version custom resource object
 func GetClusterID(r *KokuMetricsConfigReconciler, kmCfg *kokumetricscfgv1beta1.KokuMetricsConfig) error {
 	log := r.Log.WithValues("KokuMetricsConfig", "GetClusterID")
 	// Get current ClusterVersion
@@ -176,6 +176,9 @@ func GetClusterID(r *KokuMetricsConfigReconciler, kmCfg *kokumetricscfgv1beta1.K
 	log.Info("cluster version found", "ClusterVersion", clusterVersion.Spec)
 	if clusterVersion.Spec.ClusterID != "" {
 		kmCfg.Status.ClusterID = string(clusterVersion.Spec.ClusterID)
+	}
+	if clusterVersion.Spec.Channel != "" {
+		kmCfg.Status.ClusterVersion = string(clusterVersion.Spec.Channel)
 	}
 	return nil
 }

--- a/controllers/kokumetricsconfig_controller_test.go
+++ b/controllers/kokumetricsconfig_controller_test.go
@@ -32,6 +32,7 @@ var (
 	namespace                   = "koku-metrics-operator"
 	namePrefix                  = "cost-test-local-"
 	clusterID                   = "10e206d7-a11a-403e-b835-6cff14e98b23"
+	channel                     = "4.8-stable"
 	sourceName                  = "cluster-test"
 	authSecretName              = "cloud-dot-redhat"
 	authMixedCaseName           = "mixed-case"
@@ -340,6 +341,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(fetched.Status.ClusterID).To(Equal(clusterID))
+			Expect(fetched.Status.ClusterVersion).To(Equal(channel))
 			Expect(fetched.Status.Storage).ToNot(BeNil())
 			Expect(fetched.Status.Storage.VolumeMounted).To(BeTrue())
 			Expect(fetched.Status.Storage.VolumeMounted).To(BeTrue())
@@ -859,7 +861,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 		It("should attempt upload due to tar.gz being present", func() {
 			err := setup()
 			Expect(err, nil)
-			createClusterVersion(ctx, clusterID)
+			createClusterVersion(ctx, clusterID, channel)
 			deletePullSecret(ctx, openShiftConfigNamespace, fakeDockerConfig())
 			createPullSecret(ctx, openShiftConfigNamespace, fakeDockerConfig())
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -231,11 +231,12 @@ func createNamespace(ctx context.Context, namespace string) {
 	Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
 }
 
-func createClusterVersion(ctx context.Context, clusterID string) {
+func createClusterVersion(ctx context.Context, clusterID string, channel string) {
 	instance := &configv1.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{Name: "version"},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID: configv1.ClusterID(clusterID),
+			Channel:   channel,
 		},
 	}
 	Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
@@ -372,7 +373,7 @@ func clusterPrep(ctx context.Context) {
 		createPullSecret(ctx, openShiftConfigNamespace, fakeDockerConfig())
 
 		// Create cluster version
-		createClusterVersion(ctx, clusterID)
+		createClusterVersion(ctx, clusterID, channel)
 	}
 }
 

--- a/packaging/packaging.go
+++ b/packaging/packaging.go
@@ -77,7 +77,7 @@ type manifest struct {
 	Files     []string                                      `json:"files"`
 	Start     time.Time                                     `json:"start"`
 	End       time.Time                                     `json:"end"`
-	CR        kokumetricscfgv1beta1.KokuMetricsConfigStatus `json:"cr"`
+	CRStatus  kokumetricscfgv1beta1.KokuMetricsConfigStatus `json:"cr_status"`
 	Certified bool                                          `json:"certified"`
 }
 
@@ -130,7 +130,7 @@ func (p *FilePackager) getManifest(archiveFiles map[int]string, filePath string,
 			Start:     p.start.UTC(),
 			End:       p.end.UTC(),
 			Certified: isCertified,
-			CR:        kmc.Status,
+			CRStatus:  kmc.Status,
 		},
 		filename: filepath.Join(filePath, "manifest.json"),
 	}

--- a/packaging/packaging_test.go
+++ b/packaging/packaging_test.go
@@ -581,6 +581,7 @@ func TestGetAndRenderManifest(t *testing.T) {
 			expectedManifest := manifest{
 				UUID:      testPackager.uid,
 				ClusterID: testPackager.KMCfg.Status.ClusterID,
+				CRStatus:  testPackager.KMCfg.Status,
 				Version:   testPackager.KMCfg.Status.OperatorCommit,
 				Date:      manifestDate.UTC(),
 				Files:     expectedFiles,
@@ -602,6 +603,9 @@ func TestGetAndRenderManifest(t *testing.T) {
 				t.Errorf(errorMsg, expectedManifest.Start, foundManifest.Start)
 			}
 			if foundManifest.End != expectedManifest.End {
+				t.Errorf(errorMsg, expectedManifest.End, foundManifest.End)
+			}
+			if foundManifest.CRStatus.Upload.UploadToggle != expectedManifest.CRStatus.Upload.UploadToggle {
 				t.Errorf(errorMsg, expectedManifest.End, foundManifest.End)
 			}
 			for _, file := range expectedFiles {

--- a/packaging/packaging_test.go
+++ b/packaging/packaging_test.go
@@ -552,7 +552,7 @@ func TestGetAndRenderManifest(t *testing.T) {
 					t.Fatal("could not set start/end times")
 				}
 			}
-			testPackager.getManifest(csvFileNames, tt.dirName)
+			testPackager.getManifest(csvFileNames, tt.dirName, *testPackager.KMCfg)
 			if err := testPackager.manifest.renderManifest(); err != nil {
 				t.Fatal("failed to render manifest")
 			}
@@ -735,7 +735,7 @@ func TestWriteTarball(t *testing.T) {
 				csvFileNames = testPackager.buildLocalCSVFileList(tt.fileList, stagingDir)
 			}
 			manifestName := tt.manifestName
-			testPackager.getManifest(csvFileNames, stagingDir)
+			testPackager.getManifest(csvFileNames, stagingDir, *testPackager.KMCfg)
 			if err := testPackager.manifest.renderManifest(); err != nil {
 				t.Fatal("failed to render manifest")
 			}


### PR DESCRIPTION
An example of what the manifest looks like: 
```
{
 "uuid": "7bf48899-adee-4dc6-9c86-44584fbece6b",
 "cluster_id": "4e009161-4f40-42c8-877c-3e59f6baea3d",
 "version": "8c9c7b2d2729a434967a0df249cdf427e6949aae",
 "date": "2021-07-26T17:23:55.476721003Z",
 "files": [
  "7bf48899-adee-4dc6-9c86-44584fbece6b_openshift_usage_report.0.csv",
  "7bf48899-adee-4dc6-9c86-44584fbece6b_openshift_usage_report.1.csv",
  "7bf48899-adee-4dc6-9c86-44584fbece6b_openshift_usage_report.2.csv",
  "7bf48899-adee-4dc6-9c86-44584fbece6b_openshift_usage_report.3.csv"
 ],
 "start": "2021-07-26T15:00:00Z",
 "end": "2021-07-26T16:59:59Z",
 "cr_status": {
  "clusterID": "4e009161-4f40-42c8-877c-3e59f6baea3d",
  "clusterVersion": "stable-4.6",
  "api_url": "https://cloud.redhat.com",
  "authentication": {
   "type": "token"
  },
  "packaging": {
   "last_successful_packaging_time": null,
   "max_reports_to_store": 30,
   "max_size_MB": 100
  },
  "upload": {
   "ingress_path": "/api/ingress/v1/upload",
   "upload": false,
   "upload_wait": 0,
   "upload_cycle": 360,
   "last_successful_upload_time": null,
   "validate_cert": true
  },
  "operator_commit": "8c9c7b2d2729a434967a0df249cdf427e6949aae",
  "prometheus": {
   "prometheus_configured": true,
   "prometheus_connected": true,
   "last_query_start_time": "2021-07-26T17:23:54Z",
   "last_query_success_time": "2021-07-26T17:23:54Z",
   "service_address": "https://thanos-querier.openshift-monitoring.svc:9091",
   "skip_tls_verification": false
  },
  "reports": {
   "report_month": "07",
   "last_hour_queried": "2021-07-26 16:00:00 - 2021-07-26 16:59:59",
   "data_collected": true
  },
  "source": {
   "sources_path": "/api/sources/v1.0/",
   "create_source": false,
   "last_check_time": null,
   "check_cycle": 1440
  },
  "storage": {
   "volume_type": "\u0026PersistentVolumeClaimVolumeSource{ClaimName:koku-metrics-operator-data,ReadOnly:false,}",
   "volume_mounted": true
  },
  "persistent_volume_claim": {
   "kind": "PersistentVolumeClaim",
   "apiVersion": "v1",
   "metadata": {
    "name": "koku-metrics-operator-data"
   },
   "spec": {
    "accessModes": [
     "ReadWriteOnce"
    ],
    "resources": {
     "requests": {
      "storage": "10Gi"
     }
    },
    "volumeName": "pvc-137458d7-6d32-472e-8916-08f0d88aee67",
    "storageClassName": "gp2",
    "volumeMode": "Filesystem"
   }
  }
 },
 "certified": false
}
```