### PR TITLE
Add a statement to check if either the cluster version or cluster id isn't there

### DIFF
--- a/controllers/kokumetricsconfig_controller.go
+++ b/controllers/kokumetricsconfig_controller.go
@@ -298,7 +298,7 @@ func checkCycle(logger logr.Logger, cycle int64, lastExecution metav1.Time, acti
 }
 
 func setClusterID(r *KokuMetricsConfigReconciler, kmCfg *kokumetricscfgv1beta1.KokuMetricsConfig) error {
-	if kmCfg.Status.ClusterID == "" {
+	if kmCfg.Status.ClusterID == "" || kmCfg.Status.ClusterVersion == "" {
 		r.cvClientBuilder = cv.NewBuilder()
 		err := GetClusterID(r, kmCfg)
 		return err


### PR DESCRIPTION
caught this during release testing 