### PR TITLE
COST-2096: filter requests and limits on running pods

### DIFF
--- a/collector/queries.go
+++ b/collector/queries.go
@@ -128,7 +128,7 @@ var (
 		query{
 			Name:        "pod-limit-cpu-cores",
 			Chunked:     true,
-			QueryString: "sum(kube_pod_container_resource_limits{resource='cpu'}) by (pod, namespace, node)",
+			QueryString: "sum(kube_pod_container_resource_limits{resource='cpu'} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) by (pod, namespace, node)",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-limit-cpu-cores",
@@ -141,7 +141,7 @@ var (
 		query{
 			Name:        "pod-limit-memory-bytes",
 			Chunked:     true,
-			QueryString: "sum(kube_pod_container_resource_limits{resource='memory'}) by (pod, namespace, node)",
+			QueryString: "sum(kube_pod_container_resource_limits{resource='memory'} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) by (pod, namespace, node)",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-limit-memory-bytes",
@@ -154,7 +154,7 @@ var (
 		query{
 			Name:        "pod-request-cpu-cores",
 			Chunked:     true,
-			QueryString: "sum(kube_pod_container_resource_requests{resource='cpu'}) by (pod, namespace, node)",
+			QueryString: "sum(kube_pod_container_resource_requests{resource='cpu'} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) by (pod, namespace, node)",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-request-cpu-cores",
@@ -167,7 +167,7 @@ var (
 		query{
 			Name:        "pod-request-memory-bytes",
 			Chunked:     true,
-			QueryString: "sum(kube_pod_container_resource_requests{resource='memory'}) by (pod, namespace, node)",
+			QueryString: "sum(kube_pod_container_resource_requests{resource='memory'} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) by (pod, namespace, node)",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-request-memory-bytes",

--- a/controllers/kokumetricsconfig_controller.go
+++ b/controllers/kokumetricsconfig_controller.go
@@ -397,6 +397,8 @@ func setOperatorCommit(r *KokuMetricsConfigReconciler, kmCfg *kokumetricscfgv1be
 		// If the commit is different, this is either a fresh install or the operator was upgraded.
 		// After an upgrade, the report structure may differ from the old report structure,
 		// so we need to package the old files before generating new reports.
+		// We set this packaging time to zero so that the next call to packageFiles
+		// will force file packaging to occur.
 		kmCfg.Status.Packaging.LastSuccessfulPackagingTime = metav1.Time{}
 	}
 	kmCfg.Status.OperatorCommit = GitCommit

--- a/controllers/kokumetricsconfig_controller.go
+++ b/controllers/kokumetricsconfig_controller.go
@@ -665,7 +665,7 @@ func (r *KokuMetricsConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		log.Info("checking for files from an old operator version")
 		files, err := dirCfg.Reports.GetFiles()
 		if err == nil && len(files) > 0 {
-			log.Info("packaging files from an sold operator version")
+			log.Info("packaging files from an old operator version")
 			packageFiles(packager)
 		}
 	}

--- a/controllers/kokumetricsconfig_controller.go
+++ b/controllers/kokumetricsconfig_controller.go
@@ -662,9 +662,10 @@ func (r *KokuMetricsConfigReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// if packaging time is zero but there are files in the data dir, this is an upgraded operator.
 	// package all the files so that the next prometheus query generates a fresh report
 	if kmCfg.Status.Packaging.LastSuccessfulPackagingTime.IsZero() && dirCfg != nil {
+		log.Info("checking for files from an old operator version")
 		files, err := dirCfg.Reports.GetFiles()
 		if err == nil && len(files) > 0 {
-			log.Info("packaging files from old operator version")
+			log.Info("packaging files from an sold operator version")
 			packageFiles(packager)
 		}
 	}


### PR DESCRIPTION
This PR does 2 things:
1. Fixes queries that were gathering request/limits on pods that had exited
2. reworks the packaging logic so that old reports are packaged before an upgraded operator makes queries against prometheus.