### PR TITLE
[COST-992] filter out empty volumename to prevent many to many issue on PVCs

### DIFF
--- a/collector/queries.go
+++ b/collector/queries.go
@@ -72,13 +72,13 @@ var (
 	volQueries = &querys{
 		query{
 			Name:        "persistentvolume_pod_info",
-			QueryString: "kube_pod_spec_volumes_persistentvolumeclaims_info * on(persistentvolumeclaim, namespace) group_left(volumename) kube_persistentvolumeclaim_info",
+			QueryString: "kube_pod_spec_volumes_persistentvolumeclaims_info * on(persistentvolumeclaim, namespace) group_left(volumename) kube_persistentvolumeclaim_info{volumename != ''}",
 			MetricKey:   staticFields{"namespace": "namespace", "pod": "pod"},
 			RowKey:      "volumename",
 		},
 		query{
 			Name:        "persistentvolumeclaim-capacity-bytes",
-			QueryString: "kubelet_volume_stats_capacity_bytes * on(persistentvolumeclaim, namespace) group_left(volumename) kube_persistentvolumeclaim_info",
+			QueryString: "kubelet_volume_stats_capacity_bytes * on(persistentvolumeclaim, namespace) group_left(volumename) kube_persistentvolumeclaim_info{volumename != ''}",
 			QueryValue: &saveQueryValue{
 				ValName:         "persistentvolumeclaim-capacity-bytes",
 				Method:          "max",
@@ -89,7 +89,7 @@ var (
 		},
 		query{
 			Name:        "persistentvolumeclaim-request-bytes",
-			QueryString: "kube_persistentvolumeclaim_resource_requests_storage_bytes * on(persistentvolumeclaim, namespace) group_left(volumename) kube_persistentvolumeclaim_info",
+			QueryString: "kube_persistentvolumeclaim_resource_requests_storage_bytes * on(persistentvolumeclaim, namespace) group_left(volumename) kube_persistentvolumeclaim_info{volumename != ''}",
 			QueryValue: &saveQueryValue{
 				ValName:         "persistentvolumeclaim-request-bytes",
 				Method:          "max",
@@ -100,7 +100,7 @@ var (
 		},
 		query{
 			Name:        "persistentvolumeclaim-usage-bytes",
-			QueryString: "kubelet_volume_stats_used_bytes * on(persistentvolumeclaim, namespace) group_left(volumename) kube_persistentvolumeclaim_info",
+			QueryString: "kubelet_volume_stats_used_bytes * on(persistentvolumeclaim, namespace) group_left(volumename) kube_persistentvolumeclaim_info{volumename != ''}",
 			QueryValue: &saveQueryValue{
 				ValName:         "persistentvolumeclaim-usage-bytes",
 				Method:          "sum",
@@ -118,7 +118,7 @@ var (
 		},
 		query{
 			Name:           "persistentvolumeclaim-labels",
-			QueryString:    "kube_persistentvolumeclaim_labels * on(persistentvolumeclaim, namespace) group_left(volumename) kube_persistentvolumeclaim_info",
+			QueryString:    "kube_persistentvolumeclaim_labels * on(persistentvolumeclaim, namespace) group_left(volumename) kube_persistentvolumeclaim_info{volumename != ''}",
 			MetricKey:      staticFields{"namespace": "namespace", "persistentvolumeclaim": "persistentvolumeclaim"},
 			MetricKeyRegex: regexFields{"persistentvolumeclaim_labels": "label_"},
 			RowKey:         "volumename",


### PR DESCRIPTION
This issue was replicated and the many to many for PVC's can come from an empty volume name. Filtering out null volumenames in the prometheus query should address that.
