### PR TITLE
[COST-2285] - fix many-to-many query error

### DIFF
--- a/collector/queries.go
+++ b/collector/queries.go
@@ -127,7 +127,7 @@ var (
 	podQueries = &querys{
 		query{
 			Name:        "pod-limit-cpu-cores",
-			QueryString: "sum(kube_pod_container_resource_limits{resource='cpu'} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) by (pod, namespace, node)",
+			QueryString: "sum(kube_pod_container_resource_limits{resource='cpu'} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) without (instance, uid)",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-limit-cpu-cores",
@@ -139,7 +139,7 @@ var (
 		},
 		query{
 			Name:        "pod-limit-memory-bytes",
-			QueryString: "sum(kube_pod_container_resource_limits{resource='memory'} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) by (pod, namespace, node)",
+			QueryString: "sum(kube_pod_container_resource_limits{resource='memory'} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) without (instance, uid)",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-limit-memory-bytes",
@@ -151,7 +151,7 @@ var (
 		},
 		query{
 			Name:        "pod-request-cpu-cores",
-			QueryString: "sum(kube_pod_container_resource_requests{resource='cpu'} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) by (pod, namespace, node)",
+			QueryString: "sum(kube_pod_container_resource_requests{resource='cpu'} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) without (instance, uid)",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-request-cpu-cores",
@@ -163,7 +163,7 @@ var (
 		},
 		query{
 			Name:        "pod-request-memory-bytes",
-			QueryString: "sum(kube_pod_container_resource_requests{resource='memory'} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) by (pod, namespace, node)",
+			QueryString: "sum(kube_pod_container_resource_requests{resource='memory'} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) without (instance, uid)",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-request-memory-bytes",
@@ -175,7 +175,7 @@ var (
 		},
 		query{
 			Name:        "pod-usage-cpu-cores",
-			QueryString: "sum(rate(container_cpu_usage_seconds_total{container!='POD',container!='',pod!=''}[5m])) BY (pod, namespace, node)",
+			QueryString: "sum(rate(container_cpu_usage_seconds_total{container!='POD',container!='',pod!=''}[5m])) without (instance, uid)",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-usage-cpu-cores",
@@ -187,7 +187,7 @@ var (
 		},
 		query{
 			Name:        "pod-usage-memory-bytes",
-			QueryString: "sum(container_memory_usage_bytes{container!='POD', container!='',pod!=''}) by (pod, namespace, node)",
+			QueryString: "sum(container_memory_usage_bytes{container!='POD', container!='',pod!=''}) without (instance, uid)",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-usage-memory-bytes",

--- a/collector/queries.go
+++ b/collector/queries.go
@@ -127,7 +127,7 @@ var (
 	podQueries = &querys{
 		query{
 			Name:        "pod-limit-cpu-cores",
-			QueryString: "sum(kube_pod_container_resource_limits{resource='cpu'} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) without (instance, uid)",
+			QueryString: "sum(kube_pod_container_resource_limits{resource='cpu'} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) without (container, instance, uid)",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-limit-cpu-cores",
@@ -139,7 +139,7 @@ var (
 		},
 		query{
 			Name:        "pod-limit-memory-bytes",
-			QueryString: "sum(kube_pod_container_resource_limits{resource='memory'} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) without (instance, uid)",
+			QueryString: "sum(kube_pod_container_resource_limits{resource='memory'} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) without (container, instance, uid)",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-limit-memory-bytes",
@@ -151,7 +151,7 @@ var (
 		},
 		query{
 			Name:        "pod-request-cpu-cores",
-			QueryString: "sum(kube_pod_container_resource_requests{resource='cpu'} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) without (instance, uid)",
+			QueryString: "sum(kube_pod_container_resource_requests{resource='cpu'} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) without (container, instance, uid)",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-request-cpu-cores",
@@ -163,7 +163,7 @@ var (
 		},
 		query{
 			Name:        "pod-request-memory-bytes",
-			QueryString: "sum(kube_pod_container_resource_requests{resource='memory'} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) without (instance, uid)",
+			QueryString: "sum(kube_pod_container_resource_requests{resource='memory'} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) without (container, instance, uid)",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-request-memory-bytes",
@@ -175,7 +175,7 @@ var (
 		},
 		query{
 			Name:        "pod-usage-cpu-cores",
-			QueryString: "sum(rate(container_cpu_usage_seconds_total{container!='POD',container!='',pod!=''}[5m])) without (instance, uid)",
+			QueryString: "sum(rate(container_cpu_usage_seconds_total{container!='POD',container!='',pod!=''}[5m])) without (container, instance, uid)",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-usage-cpu-cores",
@@ -187,7 +187,7 @@ var (
 		},
 		query{
 			Name:        "pod-usage-memory-bytes",
-			QueryString: "sum(container_memory_usage_bytes{container!='POD', container!='',pod!=''}) without (instance, uid)",
+			QueryString: "sum(container_memory_usage_bytes{container!='POD', container!='',pod!=''}) without (container, instance, uid)",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-usage-memory-bytes",

--- a/collector/queries.go
+++ b/collector/queries.go
@@ -127,7 +127,7 @@ var (
 	podQueries = &querys{
 		query{
 			Name:        "pod-limit-cpu-cores",
-			QueryString: "sum(kube_pod_container_resource_limits{resource='cpu'} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) without (container, instance, uid)",
+			QueryString: "sum(kube_pod_container_resource_limits{resource='cpu',namespace!='',node!='',pod!=''} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) without (container, instance, uid)",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-limit-cpu-cores",
@@ -139,7 +139,7 @@ var (
 		},
 		query{
 			Name:        "pod-limit-memory-bytes",
-			QueryString: "sum(kube_pod_container_resource_limits{resource='memory'} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) without (container, instance, uid)",
+			QueryString: "sum(kube_pod_container_resource_limits{resource='memory',namespace!='',node!='',pod!=''} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) without (container, instance, uid)",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-limit-memory-bytes",
@@ -151,7 +151,7 @@ var (
 		},
 		query{
 			Name:        "pod-request-cpu-cores",
-			QueryString: "sum(kube_pod_container_resource_requests{resource='cpu'} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) without (container, instance, uid)",
+			QueryString: "sum(kube_pod_container_resource_requests{resource='cpu',namespace!='',node!='',pod!=''} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) without (container, instance, uid)",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-request-cpu-cores",
@@ -163,7 +163,7 @@ var (
 		},
 		query{
 			Name:        "pod-request-memory-bytes",
-			QueryString: "sum(kube_pod_container_resource_requests{resource='memory'} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) without (container, instance, uid)",
+			QueryString: "sum(kube_pod_container_resource_requests{resource='memory',namespace!='',node!='',pod!=''} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) without (container, instance, uid)",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-request-memory-bytes",
@@ -175,7 +175,7 @@ var (
 		},
 		query{
 			Name:        "pod-usage-cpu-cores",
-			QueryString: "sum(rate(container_cpu_usage_seconds_total{container!='POD',container!='',pod!=''}[5m])) without (container, instance, uid)",
+			QueryString: "sum(rate(container_cpu_usage_seconds_total{container!='POD',container!='',namespace!='',node!='',pod!=''}[5m])) without (container, instance, uid)",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-usage-cpu-cores",
@@ -187,7 +187,7 @@ var (
 		},
 		query{
 			Name:        "pod-usage-memory-bytes",
-			QueryString: "sum(container_memory_usage_bytes{container!='POD', container!='',pod!=''}) without (container, instance, uid)",
+			QueryString: "sum(container_memory_usage_bytes{container!='POD',container!='',namespace!='',node!='',pod!=''}) without (container, instance, uid)",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-usage-memory-bytes",
@@ -199,7 +199,8 @@ var (
 		},
 		query{
 			Name:           "pod-labels",
-			QueryString:    "kube_pod_labels",
+			QueryString:    "kube_pod_labels{namespace!='',pod!=''}",
+			MetricKey:      staticFields{"pod": "pod", "namespace": "namespace"},
 			MetricKeyRegex: regexFields{"pod_labels": "label_*"},
 			RowKey:         []model.LabelName{"pod", "namespace"},
 		},


### PR DESCRIPTION
* switch the `by (pod, namespace, node)` to `without (instance, uid)` which will prevent `many-to-many matching not allowed` errors caused by the `instance` and `uid` fields.
* add `{namespace,node,pod}!=''` because these fields are required for proper data aggregation
* add `MetricKey` to pod labels to prevent line items that are missing pod/namespace