### PR TITLE
add pod affinity to prevent multi-attach error

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -9,8 +9,8 @@ namespace: koku-metrics-operator
 namePrefix: koku-metrics-
 
 # Labels to add to all resources and selectors.
-# commonLabels:
-#  application: koku-metrics-operator
+commonLabels:
+  app: koku-metrics-operator
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -8,7 +8,7 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: operator
   namespace: operator
   labels:
     control-plane: controller-manager
@@ -22,6 +22,16 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - koku-metrics-operator
+            topologyKey: kubernetes.io/hostname
       containers:
       - command:
         - /manager

--- a/docs/csv-description.md
+++ b/docs/csv-description.md
@@ -4,7 +4,6 @@ The `koku-metrics-operator` is a component of the [cost managment](https://acces
 
 This operator is capable of functioning within a disconnected/restricted network (aka air-gapped mode). In this mode, the operator will store the packaged reports for manual retrieval instead of being uploaded to cost management. Documentation for installing an operator within a restricted network can be found [here](https://docs.openshift.com/container-platform/latest/operators/admin/olm-restricted-networks.html).
 
-For more information, reach out to <cost-mgmt@redhat.com>.
 ## Features and Capabilities
 #### Metrics collection:
 The Koku Metrics Operator (`koku-metrics-operator`) collects the metrics required for cost management by:
@@ -96,11 +95,10 @@ Configure the koku-metrics-operator by creating a `KokuMetricsConfig`.
 
 # Restricted Network Usage (disconnected/air-gapped mode)
 ## Installation
-To install the `koku-metrics-operator` in a restricted network, follow the [olm documentation](https://docs.openshift.com/container-platform/4.5/operators/admin/olm-restricted-networks.html). The operator is found in the `community-operators` Catalog in the `registry.redhat.io/redhat/community-operator-index:latest` Index. If pruning the index before pushing to the mirrored registry, keep the `koku-metrics-operator` package.
+To install the `koku-metrics-operator` in a restricted network, follow the [olm documentation](https://docs.openshift.com/container-platform/latest/operators/admin/olm-restricted-networks.html). The operator is found in the `community-operators` Catalog in the `registry.redhat.io/redhat/community-operator-index:latest` Index. If pruning the index before pushing to the mirrored registry, keep the `koku-metrics-operator` package.
 
 Within a restricted network, the operator queries prometheus to gather the necessary usage metrics, writes the query results to CSV files, and packages the reports for storage in the PVC. These reports then need to be manually downloaded from the cluster and uploaded to [console.redhat.com](https://console.redhat.com).
 
-For more information, reach out to <cost-mgmt@redhat.com>.
 ## Configure the koku-metrics-operator for a restricted network
 ##### Create the KokuMetricsConfig
 Configure the koku-metrics-operator by creating a `KokuMetricsConfig`.
@@ -154,7 +152,19 @@ If the `koku-metrics-operator` is configured to run in a restricted network, the
     metadata:
       name: volume-shell
       namespace: koku-metrics-operator
+      labels:
+        app: koku-metrics-operator
     spec:
+     affinity:
+       podAffinity:
+         requiredDuringSchedulingIgnoredDuringExecution:
+         - labelSelector:
+             matchExpressions:
+             - key: app
+               operator: In
+               values:
+               - koku-metrics-operator
+           topologyKey: kubernetes.io/hostname
       volumes:
       - name: koku-metrics-operator-reports
         persistentVolumeClaim:


### PR DESCRIPTION
* add a new common label (`app: koku-metrics-operator`)
* add pod affinity to utilize this label
* update deployment name so that OLM will replace the old deployments (as described [here](https://github.com/operator-framework/operator-lifecycle-manager/issues/952#issuecomment-639657949)). The `commonLabels` change will add a new `selector: matchLabels:` label. `selector: matchLabels:` are immutable, so to correctly apply a new one, a deployment must be recreated.