### PR TITLE
[COST-2285] - update prometheus queries for many-to-many matching error

### DIFF
--- a/collector/queries.go
+++ b/collector/queries.go
@@ -175,7 +175,7 @@ var (
 		},
 		query{
 			Name:        "pod-usage-cpu-cores",
-			QueryString: "sum(rate(container_cpu_usage_seconds_total{container!='POD',container!='',namespace!='',node!='',pod!=''}[5m])) without (container, instance, uid)",
+			QueryString: "sum by (namespace, node, pod) (rate(container_cpu_usage_seconds_total{container!='POD',container!='',namespace!='',node!='',pod!=''}[5m]))",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-usage-cpu-cores",
@@ -187,7 +187,7 @@ var (
 		},
 		query{
 			Name:        "pod-usage-memory-bytes",
-			QueryString: "sum(container_memory_usage_bytes{container!='POD',container!='',namespace!='',node!='',pod!=''}) without (container, instance, uid)",
+			QueryString: "sum by (namespace, node, pod) (container_memory_usage_bytes{container!='POD',container!='',namespace!='',node!='',pod!=''})",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-usage-memory-bytes",

--- a/collector/queries.go
+++ b/collector/queries.go
@@ -127,7 +127,7 @@ var (
 	podQueries = &querys{
 		query{
 			Name:        "pod-limit-cpu-cores",
-			QueryString: "sum(kube_pod_container_resource_limits{resource='cpu',namespace!='',node!='',pod!=''} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) without (container, instance, uid)",
+			QueryString: "sum by (namespace, node, pod) (kube_pod_container_resource_limits{resource='cpu',namespace!='',node!='',pod!=''} * on(namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{phase='Running'}))",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-limit-cpu-cores",
@@ -139,7 +139,7 @@ var (
 		},
 		query{
 			Name:        "pod-limit-memory-bytes",
-			QueryString: "sum(kube_pod_container_resource_limits{resource='memory',namespace!='',node!='',pod!=''} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) without (container, instance, uid)",
+			QueryString: "sum by (namespace, node, pod) (kube_pod_container_resource_limits{resource='memory',namespace!='',node!='',pod!=''} * on(namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{phase='Running'}))",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-limit-memory-bytes",
@@ -151,7 +151,7 @@ var (
 		},
 		query{
 			Name:        "pod-request-cpu-cores",
-			QueryString: "sum(kube_pod_container_resource_requests{resource='cpu',namespace!='',node!='',pod!=''} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) without (container, instance, uid)",
+			QueryString: "sum by (namespace, node, pod) (kube_pod_container_resource_requests{resource='cpu',namespace!='',node!='',pod!=''} * on(namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{phase='Running'}))",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-request-cpu-cores",
@@ -163,7 +163,7 @@ var (
 		},
 		query{
 			Name:        "pod-request-memory-bytes",
-			QueryString: "sum(kube_pod_container_resource_requests{resource='memory',namespace!='',node!='',pod!=''} * on(pod, namespace) group_left kube_pod_status_phase{phase='Running'}) without (container, instance, uid)",
+			QueryString: "sum by (namespace, node, pod) (kube_pod_container_resource_requests{resource='memory',namespace!='',node!='',pod!=''} * on(namespace, pod) group_left() max by (namespace, pod) (kube_pod_status_phase{phase='Running'}))",
 			MetricKey:   staticFields{"pod": "pod", "namespace": "namespace", "node": "node"},
 			QueryValue: &saveQueryValue{
 				ValName:         "pod-request-memory-bytes",


### PR DESCRIPTION
* Update the resource limits/requests queries to aggregate away the other dimensions on the right-hand side of the expression using `max()`.
* Update the usage queries to group by the same params as the limits/requests instead of relying on the `without` clause.