### PR TITLE
add polling context timeout

### DIFF
--- a/collector/prometheus.go
+++ b/collector/prometheus.go
@@ -131,8 +131,10 @@ func statusHelper(kmCfg *kokumetricscfgv1beta1.KokuMetricsConfig, status string,
 }
 
 func testPrometheusConnection(promConn prometheusConnection) error {
-	return wait.Poll(1*time.Second, 15*time.Second, func() (bool, error) {
-		_, _, err := promConn.Query(context.TODO(), "up", time.Now())
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	return wait.PollImmediate(1*time.Second, 15*time.Second, func() (bool, error) {
+		_, _, err := promConn.Query(ctx, "up", time.Now())
 		if err != nil {
 			return false, err
 		}

--- a/collector/prometheus.go
+++ b/collector/prometheus.go
@@ -131,7 +131,7 @@ func statusHelper(kmCfg *kokumetricscfgv1beta1.KokuMetricsConfig, status string,
 }
 
 func testPrometheusConnection(promConn prometheusConnection) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	return wait.PollImmediate(1*time.Second, 15*time.Second, func() (bool, error) {
 		_, _, err := promConn.Query(ctx, "up", time.Now())

--- a/collector/report_test.go
+++ b/collector/report_test.go
@@ -12,7 +12,10 @@ import (
 	"github.com/project-koku/koku-metrics-operator/strset"
 )
 
-var errTest = errors.New("test error")
+var (
+	ctxTimeout = errors.New("context timeout")
+	errTest    = errors.New("test error")
+)
 
 type badReader struct{}
 


### PR DESCRIPTION
[COST-3245](https://issues.redhat.com/browse/COST-3245)

This could potentially fix an issue where the operator stops functioning during this Poll function. Adding a context with a timeout might break out of this Poll when the context is exceeded.