### PR TITLE
COST-2665: Added kube-linter ignore check for controller-manager

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -12,6 +12,9 @@ metadata:
   namespace: operator
   labels:
     control-plane: controller-manager
+  annotations:
+    ignore-check.kube-linter.io/minimum-three-replicas: This deployment uses
+      1 pod as currently it supports only a single controller-manager
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
* Add annotation to ignore the kube-linter check for 3 replicas on the controller-manager

Related:
https://issues.redhat.com/browse/COST-2665
https://issues.redhat.com/browse/COST-2669