### PR TITLE
remove "koku" from naming convention

### DIFF
--- a/api/v1beta1/metricsconfig_types.go
+++ b/api/v1beta1/metricsconfig_types.go
@@ -509,3 +509,12 @@ type KokuMetricsConfigList struct {
 func init() {
 	SchemeBuilder.Register(&KokuMetricsConfig{}, &KokuMetricsConfigList{})
 }
+
+// +kubebuilder:object:generate:=false
+type MetricsConfig = KokuMetricsConfig
+
+// +kubebuilder:object:generate:=false
+type MetricsConfigSpec = KokuMetricsConfigSpec
+
+// +kubebuilder:object:generate:=false
+type MetricsConfigStatus = KokuMetricsConfigStatus

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -17,7 +17,7 @@ import (
 	"github.com/prometheus/common/model"
 	logr "sigs.k8s.io/controller-runtime/pkg/log"
 
-	kokumetricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
+	metricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
 	"github.com/project-koku/koku-metrics-operator/dirconfig"
 )
 
@@ -129,7 +129,7 @@ func (r *mappedResults) iterateMatrix(matrix model.Matrix, q query) {
 }
 
 // GenerateReports is responsible for querying prometheus and writing to report files
-func GenerateReports(cr *kokumetricscfgv1beta1.KokuMetricsConfig, dirCfg *dirconfig.DirectoryConfig, c *PrometheusCollector) error {
+func GenerateReports(cr *metricscfgv1beta1.MetricsConfig, dirCfg *dirconfig.DirectoryConfig, c *PrometheusCollector) error {
 	log := log.WithName("GenerateReports")
 
 	// yearMonth is used in filenames
@@ -309,7 +309,7 @@ func findFields(input model.Metric, str string) string {
 	}
 }
 
-func updateReportStatus(cr *kokumetricscfgv1beta1.KokuMetricsConfig, ts *promv1.Range) {
+func updateReportStatus(cr *metricscfgv1beta1.MetricsConfig, ts *promv1.Range) {
 	cr.Status.Reports.ReportMonth = ts.Start.Format("01")
 	cr.Status.Reports.LastHourQueried = ts.Start.Format(statusTimeFormat) + " - " + ts.End.Format(statusTimeFormat)
 }

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/prometheus/common/model"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	kokumetricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
+	metricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
 	"github.com/project-koku/koku-metrics-operator/dirconfig"
 	"github.com/project-koku/koku-metrics-operator/strset"
 	"github.com/project-koku/koku-metrics-operator/testutils"
@@ -61,7 +61,7 @@ func Load(path string, v interface{}, t *testing.T) {
 }
 
 var (
-	fakeKMCfg  = &kokumetricscfgv1beta1.KokuMetricsConfig{}
+	fakeKMCfg  = &metricscfgv1beta1.MetricsConfig{}
 	fakeDirCfg = &dirconfig.DirectoryConfig{
 		Parent:  dirconfig.Directory{Path: "."},
 		Reports: dirconfig.Directory{Path: "./test_files/test_reports"},

--- a/collector/prometheus.go
+++ b/collector/prometheus.go
@@ -19,11 +19,11 @@ import (
 	"github.com/prometheus/common/model"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	kokumetricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
+	metricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
 )
 
 var (
-	ps *kokumetricscfgv1beta1.PrometheusSpec
+	ps *metricscfgv1beta1.PrometheusSpec
 
 	pollingCtxTimeout = 15 * time.Second
 
@@ -58,7 +58,7 @@ func getBearerToken(tokenFile string) (config.Secret, error) {
 	return config.Secret(encodedSecret), nil
 }
 
-func statusHelper(cr *kokumetricscfgv1beta1.KokuMetricsConfig, status string, err error) {
+func statusHelper(cr *metricscfgv1beta1.MetricsConfig, status string, err error) {
 	switch status {
 	case "configuration":
 		if err != nil {
@@ -79,9 +79,9 @@ func statusHelper(cr *kokumetricscfgv1beta1.KokuMetricsConfig, status string, er
 	}
 }
 
-type PrometheusConfigurationSetter func(ps *kokumetricscfgv1beta1.PrometheusSpec, c *PrometheusCollector) error
+type PrometheusConfigurationSetter func(ps *metricscfgv1beta1.PrometheusSpec, c *PrometheusCollector) error
 
-func SetPrometheusConfig(ps *kokumetricscfgv1beta1.PrometheusSpec, c *PrometheusCollector) error {
+func SetPrometheusConfig(ps *metricscfgv1beta1.PrometheusSpec, c *PrometheusCollector) error {
 
 	pCfg := &PrometheusConfig{
 		Address: ps.SvcAddress,
@@ -157,7 +157,7 @@ func NewPromCollector(saPath string) *PrometheusCollector {
 
 // GetPromConn returns the prometheus connection
 func (c *PrometheusCollector) GetPromConn(
-	cr *kokumetricscfgv1beta1.KokuMetricsConfig,
+	cr *metricscfgv1beta1.MetricsConfig,
 	pcfgs PrometheusConfigurationSetter,
 	pcs PrometheusConnectionSetter,
 	pct PrometheusConnectionTester,

--- a/collector/prometheus_test.go
+++ b/collector/prometheus_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 
-	kokumetricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
+	metricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
 	"github.com/project-koku/koku-metrics-operator/testutils"
 )
 
@@ -362,35 +362,35 @@ func TestTestPrometheusConnectionPolling(t *testing.T) {
 func TestStatusHelper(t *testing.T) {
 	statusHelperTests := []struct {
 		name   string
-		cr     *kokumetricscfgv1beta1.KokuMetricsConfig
+		cr     *metricscfgv1beta1.MetricsConfig
 		status string
 		want   bool
 		err    error
 	}{
 		{
 			name:   "config success",
-			cr:     &kokumetricscfgv1beta1.KokuMetricsConfig{},
+			cr:     &metricscfgv1beta1.MetricsConfig{},
 			status: "configuration",
 			want:   true,
 			err:    nil,
 		},
 		{
 			name:   "config failed",
-			cr:     &kokumetricscfgv1beta1.KokuMetricsConfig{},
+			cr:     &metricscfgv1beta1.MetricsConfig{},
 			status: "configuration",
 			want:   false,
 			err:    errTest,
 		},
 		{
 			name:   "connection success",
-			cr:     &kokumetricscfgv1beta1.KokuMetricsConfig{},
+			cr:     &metricscfgv1beta1.MetricsConfig{},
 			status: "connection",
 			want:   true,
 			err:    nil,
 		},
 		{
 			name:   "connection failed",
-			cr:     &kokumetricscfgv1beta1.KokuMetricsConfig{},
+			cr:     &metricscfgv1beta1.MetricsConfig{},
 			status: "connection",
 			want:   false,
 			err:    errTest,
@@ -541,7 +541,7 @@ func TestGetPromConn(t *testing.T) {
 					os.Remove(toke)
 				}()
 			}
-			cr := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+			cr := &metricscfgv1beta1.MetricsConfig{}
 			cr.Status.Prometheus.ConfigError = tt.cfgErr
 			cr.Status.Prometheus.ConnectionError = tt.conErr
 			cr.Spec.PrometheusConfig.SkipTLSVerification = &trueDef
@@ -564,7 +564,7 @@ func TestGetPromConn(t *testing.T) {
 
 func TestSetPrometheusConfig(t *testing.T) {
 	trueDef := true
-	ps := &kokumetricscfgv1beta1.PrometheusSpec{
+	ps := &metricscfgv1beta1.PrometheusSpec{
 		SvcAddress:          "svc-address",
 		SkipTLSVerification: &trueDef,
 	}

--- a/controllers/kokumetricsconfig_controller.go
+++ b/controllers/kokumetricsconfig_controller.go
@@ -60,7 +60,7 @@ var (
 	promConnSetter     collector.PrometheusConnectionSetter    = collector.SetPrometheusConnection
 	promConnTester     collector.PrometheusConnectionTester    = collector.TestPrometheusConnection
 
-	log = logr.Log.WithName("controller_kokumetricsconfig")
+	log = logr.Log.WithName("metricsconfig_controller")
 )
 
 // MetricsConfigReconciler reconciles a MetricsConfig object

--- a/controllers/kokumetricsconfig_controller_test.go
+++ b/controllers/kokumetricsconfig_controller_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	kokumetricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
+	metricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
 	"github.com/project-koku/koku-metrics-operator/collector"
 	"github.com/project-koku/koku-metrics-operator/storage"
 	"github.com/project-koku/koku-metrics-operator/testutils"
@@ -52,30 +52,30 @@ var (
 	defaultUploadWait     int64 = 0
 	defaultMaxReports     int64 = 1
 	defaultAPIURL               = "https://not-the-real-cloud.redhat.com"
-	instance                    = kokumetricscfgv1beta1.KokuMetricsConfig{
+	instance                    = metricscfgv1beta1.MetricsConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 		},
-		Spec: kokumetricscfgv1beta1.KokuMetricsConfigSpec{
-			Authentication: kokumetricscfgv1beta1.AuthenticationSpec{
-				AuthType: kokumetricscfgv1beta1.Token,
+		Spec: metricscfgv1beta1.MetricsConfigSpec{
+			Authentication: metricscfgv1beta1.AuthenticationSpec{
+				AuthType: metricscfgv1beta1.Token,
 			},
-			Packaging: kokumetricscfgv1beta1.PackagingSpec{
+			Packaging: metricscfgv1beta1.PackagingSpec{
 				MaxSize:    100,
 				MaxReports: defaultMaxReports,
 			},
-			Upload: kokumetricscfgv1beta1.UploadSpec{
+			Upload: metricscfgv1beta1.UploadSpec{
 				UploadCycle:    &defaultUploadCycle,
 				UploadToggle:   &trueValue,
 				IngressAPIPath: "/api/ingress/v1/upload",
 				ValidateCert:   &trueValue,
 			},
-			Source: kokumetricscfgv1beta1.CloudDotRedHatSourceSpec{
+			Source: metricscfgv1beta1.CloudDotRedHatSourceSpec{
 				CreateSource:   &falseValue,
 				SourcesAPIPath: "/api/sources/v1.0/",
 				CheckCycle:     &defaultCheckCycle,
 			},
-			PrometheusConfig: kokumetricscfgv1beta1.PrometheusSpec{
+			PrometheusConfig: metricscfgv1beta1.PrometheusSpec{
 				ContextTimeout:      &defaultContextTimeout,
 				SkipTLSVerification: &trueValue,
 				SvcAddress:          "https://thanos-querier.openshift-monitoring.svc:9091",
@@ -83,30 +83,30 @@ var (
 			APIURL: "https://not-the-real-cloud.redhat.com",
 		},
 	}
-	airGappedInstance = kokumetricscfgv1beta1.KokuMetricsConfig{
+	airGappedInstance = metricscfgv1beta1.MetricsConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 		},
-		Spec: kokumetricscfgv1beta1.KokuMetricsConfigSpec{
-			Authentication: kokumetricscfgv1beta1.AuthenticationSpec{
-				AuthType: kokumetricscfgv1beta1.Token,
+		Spec: metricscfgv1beta1.MetricsConfigSpec{
+			Authentication: metricscfgv1beta1.AuthenticationSpec{
+				AuthType: metricscfgv1beta1.Token,
 			},
-			Packaging: kokumetricscfgv1beta1.PackagingSpec{
+			Packaging: metricscfgv1beta1.PackagingSpec{
 				MaxSize:    100,
 				MaxReports: defaultMaxReports,
 			},
-			Upload: kokumetricscfgv1beta1.UploadSpec{
+			Upload: metricscfgv1beta1.UploadSpec{
 				UploadCycle:    &defaultUploadCycle,
 				UploadToggle:   &falseValue,
 				IngressAPIPath: "/api/ingress/v1/upload",
 				ValidateCert:   &trueValue,
 			},
-			Source: kokumetricscfgv1beta1.CloudDotRedHatSourceSpec{
+			Source: metricscfgv1beta1.CloudDotRedHatSourceSpec{
 				CreateSource:   &falseValue,
 				SourcesAPIPath: "/api/sources/v1.0/",
 				CheckCycle:     &defaultCheckCycle,
 			},
-			PrometheusConfig: kokumetricscfgv1beta1.PrometheusSpec{
+			PrometheusConfig: metricscfgv1beta1.PrometheusSpec{
 				ContextTimeout:      &diffContextTimeout,
 				SkipTLSVerification: &trueValue,
 				SvcAddress:          "https://thanos-querier.openshift-monitoring.svc:9091",
@@ -114,12 +114,12 @@ var (
 			APIURL: "https://not-the-real-cloud.redhat.com",
 		},
 	}
-	differentPVC = &kokumetricscfgv1beta1.EmbeddedPersistentVolumeClaim{
+	differentPVC = &metricscfgv1beta1.EmbeddedPersistentVolumeClaim{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "PersistentVolumeClaim",
 		},
-		EmbeddedObjectMetadata: kokumetricscfgv1beta1.EmbeddedObjectMetadata{
+		EmbeddedObjectMetadata: metricscfgv1beta1.EmbeddedObjectMetadata{
 			Name: "a-different-pvc",
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
@@ -309,7 +309,7 @@ func shutdown() {
 	os.RemoveAll("/tmp/koku-metrics-operator-reports/")
 }
 
-var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
+var _ = Describe("MetricsConfigController - CRD Handling", func() {
 
 	const timeout = time.Second * 60
 	const interval = time.Second * 1
@@ -364,7 +364,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 			instCopy.ObjectMeta.Name = namePrefix + "no-pvc-spec-2"
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
-			fetched := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+			fetched := &metricscfgv1beta1.MetricsConfig{}
 
 			// wait until the deployment vol has changed
 			Eventually(func() bool {
@@ -423,7 +423,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 			instCopy.Spec.VolumeClaimTemplate = differentPVC
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
-			fetched := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+			fetched := &metricscfgv1beta1.MetricsConfig{}
 
 			// wait until the deployment vol has changed
 			Eventually(func() bool {
@@ -448,11 +448,11 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 			instCopy := airGappedInstance.DeepCopy()
 			instCopy.Spec.APIURL = unauthorizedTS.URL
 			instCopy.ObjectMeta.Name = namePrefix + "default-cr-air-gapped-basic"
-			instCopy.Spec.Authentication.AuthType = kokumetricscfgv1beta1.Basic
+			instCopy.Spec.Authentication.AuthType = metricscfgv1beta1.Basic
 			instCopy.Spec.Authentication.AuthenticationSecretName = "not-existent-secret"
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
-			fetched := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+			fetched := &metricscfgv1beta1.MetricsConfig{}
 
 			// wait until the cluster ID is set
 			Eventually(func() bool {
@@ -460,7 +460,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 				return fetched.Status.ClusterID != ""
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(fetched.Status.Authentication.AuthType).To(Equal(kokumetricscfgv1beta1.Basic))
+			Expect(fetched.Status.Authentication.AuthType).To(Equal(metricscfgv1beta1.Basic))
 			Expect(fetched.Status.Authentication.AuthenticationCredentialsFound).To(BeNil())
 			Expect(fetched.Status.Authentication.ValidBasicAuth).To(BeNil())
 
@@ -482,7 +482,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 			instCopy.ObjectMeta.Name = namePrefix + "default-cr-air-gapped-token"
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
-			fetched := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+			fetched := &metricscfgv1beta1.MetricsConfig{}
 
 			// wait until the cluster ID is set
 			Eventually(func() bool {
@@ -490,7 +490,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 				return fetched.Status.ClusterID != ""
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(fetched.Status.Authentication.AuthType).To(Equal(kokumetricscfgv1beta1.DefaultAuthenticationType))
+			Expect(fetched.Status.Authentication.AuthType).To(Equal(metricscfgv1beta1.DefaultAuthenticationType))
 			Expect(fetched.Status.Authentication.AuthenticationCredentialsFound).To(BeNil())
 
 			Expect(fetched.Status.APIURL).To(Equal(unauthorizedTS.URL))
@@ -515,7 +515,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 			instCopy.Spec.Source.SourceName = "INSERT-SOURCE-NAME"
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
-			fetched := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+			fetched := &metricscfgv1beta1.MetricsConfig{}
 
 			// wait until the cluster ID is set
 			Eventually(func() bool {
@@ -523,7 +523,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 				return fetched.Status.Authentication.AuthenticationCredentialsFound != nil
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(fetched.Status.Authentication.AuthType).To(Equal(kokumetricscfgv1beta1.DefaultAuthenticationType))
+			Expect(fetched.Status.Authentication.AuthType).To(Equal(metricscfgv1beta1.DefaultAuthenticationType))
 			Expect(*fetched.Status.Authentication.AuthenticationCredentialsFound).To(BeTrue())
 			Expect(fetched.Status.Authentication.ValidBasicAuth).To(BeNil())
 			Expect(fetched.Status.APIURL).To(Equal(validTS.URL))
@@ -544,7 +544,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
-			fetched := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+			fetched := &metricscfgv1beta1.MetricsConfig{}
 
 			// wait until the cluster ID is set
 			Eventually(func() bool {
@@ -552,7 +552,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 				return fetched.Status.ClusterID != ""
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(fetched.Status.Authentication.AuthType).To(Equal(kokumetricscfgv1beta1.DefaultAuthenticationType))
+			Expect(fetched.Status.Authentication.AuthType).To(Equal(metricscfgv1beta1.DefaultAuthenticationType))
 			Expect(fetched.Status.Authentication.AuthenticationCredentialsFound).To(BeNil())
 			Expect(fetched.Status.APIURL).To(Equal(defaultAPIURL))
 			Expect(fetched.Status.ClusterID).To(Equal(clusterID))
@@ -565,11 +565,11 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 			instCopy := instance.DeepCopy()
 			instCopy.ObjectMeta.Name = namePrefix + "basicauthgood"
 			instCopy.Spec.APIURL = validTS.URL
-			instCopy.Spec.Authentication.AuthType = kokumetricscfgv1beta1.Basic
+			instCopy.Spec.Authentication.AuthType = metricscfgv1beta1.Basic
 			instCopy.Spec.Authentication.AuthenticationSecretName = authSecretName
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
-			fetched := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+			fetched := &metricscfgv1beta1.MetricsConfig{}
 
 			// wait until the cluster ID is set
 			Eventually(func() bool {
@@ -577,7 +577,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 				return fetched.Status.Authentication.AuthenticationCredentialsFound != nil
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(fetched.Status.Authentication.AuthType).To(Equal(kokumetricscfgv1beta1.Basic))
+			Expect(fetched.Status.Authentication.AuthType).To(Equal(metricscfgv1beta1.Basic))
 			Expect(fetched.Status.Authentication.AuthenticationSecretName).To(Equal(authSecretName))
 			Expect(*fetched.Status.Authentication.AuthenticationCredentialsFound).To(BeTrue())
 			Expect(*fetched.Status.Authentication.ValidBasicAuth).To(BeTrue())
@@ -591,11 +591,11 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 			instCopy := instance.DeepCopy()
 			instCopy.ObjectMeta.Name = namePrefix + "basicauthgood-unauthorized"
 			instCopy.Spec.APIURL = unauthorizedTS.URL
-			instCopy.Spec.Authentication.AuthType = kokumetricscfgv1beta1.Basic
+			instCopy.Spec.Authentication.AuthType = metricscfgv1beta1.Basic
 			instCopy.Spec.Authentication.AuthenticationSecretName = authSecretName
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
-			fetched := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+			fetched := &metricscfgv1beta1.MetricsConfig{}
 
 			// wait until the cluster ID is set
 			Eventually(func() bool {
@@ -603,7 +603,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 				return fetched.Status.Authentication.AuthenticationCredentialsFound != nil
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(fetched.Status.Authentication.AuthType).To(Equal(kokumetricscfgv1beta1.Basic))
+			Expect(fetched.Status.Authentication.AuthType).To(Equal(metricscfgv1beta1.Basic))
 			Expect(fetched.Status.Authentication.AuthenticationSecretName).To(Equal(authSecretName))
 			Expect(*fetched.Status.Authentication.AuthenticationCredentialsFound).To(BeTrue())
 			Expect(*fetched.Status.Authentication.ValidBasicAuth).To(BeFalse())
@@ -618,11 +618,11 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 			instCopy := instance.DeepCopy()
 			instCopy.ObjectMeta.Name = namePrefix + "mixed-case"
 			instCopy.Spec.APIURL = validTS.URL
-			instCopy.Spec.Authentication.AuthType = kokumetricscfgv1beta1.Basic
+			instCopy.Spec.Authentication.AuthType = metricscfgv1beta1.Basic
 			instCopy.Spec.Authentication.AuthenticationSecretName = authMixedCaseName
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
-			fetched := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+			fetched := &metricscfgv1beta1.MetricsConfig{}
 
 			// wait until the cluster ID is set
 			Eventually(func() bool {
@@ -630,7 +630,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 				return fetched.Status.Authentication.AuthenticationCredentialsFound != nil
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(fetched.Status.Authentication.AuthType).To(Equal(kokumetricscfgv1beta1.Basic))
+			Expect(fetched.Status.Authentication.AuthType).To(Equal(metricscfgv1beta1.Basic))
 			Expect(fetched.Status.Authentication.AuthenticationSecretName).To(Equal(authMixedCaseName))
 			Expect(*fetched.Status.Authentication.AuthenticationCredentialsFound).To(BeTrue())
 			Expect(*fetched.Status.Authentication.ValidBasicAuth).To(BeTrue())
@@ -644,19 +644,19 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 			badAuth := "bad-auth"
 			instCopy := instance.DeepCopy()
 			instCopy.ObjectMeta.Name = namePrefix + "basicauthbad"
-			instCopy.Spec.Authentication.AuthType = kokumetricscfgv1beta1.Basic
+			instCopy.Spec.Authentication.AuthType = metricscfgv1beta1.Basic
 			instCopy.Spec.Authentication.AuthenticationSecretName = badAuth
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
-			fetched := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+			fetched := &metricscfgv1beta1.MetricsConfig{}
 			// wait until the cluster ID is set
 			Eventually(func() bool {
 				_ = k8sClient.Get(ctx, types.NamespacedName{Name: instCopy.Name, Namespace: namespace}, fetched)
 				return fetched.Status.Authentication.AuthenticationCredentialsFound != nil
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(fetched.Status.Authentication.AuthType).To(Equal(kokumetricscfgv1beta1.Basic))
+			Expect(fetched.Status.Authentication.AuthType).To(Equal(metricscfgv1beta1.Basic))
 			Expect(fetched.Status.Authentication.AuthenticationSecretName).To(Equal(badAuth))
 			Expect(*fetched.Status.Authentication.AuthenticationCredentialsFound).To(BeFalse())
 			Expect(fetched.Status.Authentication.AuthErrorMessage).ToNot(Equal(""))
@@ -674,7 +674,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 			instCopy.Spec.Source.SourceName = sourceName
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
-			fetched := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+			fetched := &metricscfgv1beta1.MetricsConfig{}
 
 			// wait until the cluster ID is set
 			Eventually(func() bool {
@@ -682,7 +682,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 				return fetched.Status.Authentication.AuthenticationCredentialsFound != nil
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(fetched.Status.Authentication.AuthType).To(Equal(kokumetricscfgv1beta1.DefaultAuthenticationType))
+			Expect(fetched.Status.Authentication.AuthType).To(Equal(metricscfgv1beta1.DefaultAuthenticationType))
 			Expect(*fetched.Status.Authentication.AuthenticationCredentialsFound).To(BeTrue())
 			Expect(fetched.Status.APIURL).To(Equal(defaultAPIURL))
 			Expect(fetched.Status.ClusterID).To(Equal(clusterID))
@@ -700,7 +700,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 			instCopy.Spec.Source.CreateSource = &trueValue
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
-			fetched := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+			fetched := &metricscfgv1beta1.MetricsConfig{}
 
 			// wait until the cluster ID is set
 			Eventually(func() bool {
@@ -708,7 +708,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 				return fetched.Status.Authentication.AuthenticationCredentialsFound != nil
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(fetched.Status.Authentication.AuthType).To(Equal(kokumetricscfgv1beta1.DefaultAuthenticationType))
+			Expect(fetched.Status.Authentication.AuthType).To(Equal(metricscfgv1beta1.DefaultAuthenticationType))
 			Expect(*fetched.Status.Authentication.AuthenticationCredentialsFound).To(BeTrue())
 			Expect(fetched.Status.APIURL).To(Equal(defaultAPIURL))
 			Expect(fetched.Status.ClusterID).To(Equal(clusterID))
@@ -721,12 +721,12 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 		It("should fail due to bad basic auth secret", func() {
 			instCopy := instance.DeepCopy()
 			instCopy.ObjectMeta.Name = namePrefix + "badauthsecret"
-			instCopy.Spec.Authentication.AuthType = kokumetricscfgv1beta1.Basic
+			instCopy.Spec.Authentication.AuthType = metricscfgv1beta1.Basic
 			instCopy.Spec.Authentication.AuthenticationSecretName = badAuthSecretName
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
-			fetched := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+			fetched := &metricscfgv1beta1.MetricsConfig{}
 
 			// wait until the cluster ID is set
 			Eventually(func() bool {
@@ -734,7 +734,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 				return fetched.Status.Authentication.AuthenticationCredentialsFound != nil
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(fetched.Status.Authentication.AuthType).To(Equal(kokumetricscfgv1beta1.Basic))
+			Expect(fetched.Status.Authentication.AuthType).To(Equal(metricscfgv1beta1.Basic))
 			Expect(fetched.Status.Authentication.AuthenticationSecretName).To(Equal(badAuthSecretName))
 			Expect(*fetched.Status.Authentication.AuthenticationCredentialsFound).To(BeFalse())
 			Expect(fetched.Status.Authentication.AuthErrorMessage).ToNot(Equal(""))
@@ -748,12 +748,12 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 		It("should fail due to missing pass in auth secret", func() {
 			instCopy := instance.DeepCopy()
 			instCopy.ObjectMeta.Name = namePrefix + "badpass"
-			instCopy.Spec.Authentication.AuthType = kokumetricscfgv1beta1.Basic
+			instCopy.Spec.Authentication.AuthType = metricscfgv1beta1.Basic
 			instCopy.Spec.Authentication.AuthenticationSecretName = badAuthPassSecretName
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
-			fetched := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+			fetched := &metricscfgv1beta1.MetricsConfig{}
 
 			// wait until the cluster ID is set
 			Eventually(func() bool {
@@ -761,7 +761,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 				return fetched.Status.Authentication.AuthenticationCredentialsFound != nil
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(fetched.Status.Authentication.AuthType).To(Equal(kokumetricscfgv1beta1.Basic))
+			Expect(fetched.Status.Authentication.AuthType).To(Equal(metricscfgv1beta1.Basic))
 			Expect(fetched.Status.Authentication.AuthenticationSecretName).To(Equal(badAuthPassSecretName))
 			Expect(*fetched.Status.Authentication.AuthenticationCredentialsFound).To(BeFalse())
 			Expect(fetched.Status.Authentication.AuthErrorMessage).ToNot(Equal(""))
@@ -775,12 +775,12 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 		It("should fail due to missing user in auth secret", func() {
 			instCopy := instance.DeepCopy()
 			instCopy.ObjectMeta.Name = namePrefix + "baduser"
-			instCopy.Spec.Authentication.AuthType = kokumetricscfgv1beta1.Basic
+			instCopy.Spec.Authentication.AuthType = metricscfgv1beta1.Basic
 			instCopy.Spec.Authentication.AuthenticationSecretName = badAuthUserSecretName
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
-			fetched := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+			fetched := &metricscfgv1beta1.MetricsConfig{}
 
 			// wait until the cluster ID is set
 			Eventually(func() bool {
@@ -788,7 +788,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 				return fetched.Status.Authentication.AuthenticationCredentialsFound != nil
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(fetched.Status.Authentication.AuthType).To(Equal(kokumetricscfgv1beta1.Basic))
+			Expect(fetched.Status.Authentication.AuthType).To(Equal(metricscfgv1beta1.Basic))
 			Expect(fetched.Status.Authentication.AuthenticationSecretName).To(Equal(badAuthUserSecretName))
 			Expect(*fetched.Status.Authentication.AuthenticationCredentialsFound).To(BeFalse())
 			Expect(fetched.Status.Authentication.AuthErrorMessage).ToNot(Equal(""))
@@ -802,11 +802,11 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 		It("should fail due to missing auth secret name with basic set", func() {
 			instCopy := instance.DeepCopy()
 			instCopy.ObjectMeta.Name = namePrefix + "missingname"
-			instCopy.Spec.Authentication.AuthType = kokumetricscfgv1beta1.Basic
+			instCopy.Spec.Authentication.AuthType = metricscfgv1beta1.Basic
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
-			fetched := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+			fetched := &metricscfgv1beta1.MetricsConfig{}
 
 			// wait until the cluster ID is set
 			Eventually(func() bool {
@@ -814,7 +814,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 				return fetched.Status.Authentication.AuthenticationCredentialsFound != nil
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(fetched.Status.Authentication.AuthType).To(Equal(kokumetricscfgv1beta1.Basic))
+			Expect(fetched.Status.Authentication.AuthType).To(Equal(metricscfgv1beta1.Basic))
 			Expect(fetched.Status.Authentication.AuthenticationSecretName).To(Equal(""))
 			Expect(*fetched.Status.Authentication.AuthenticationCredentialsFound).To(BeFalse())
 			Expect(fetched.Status.Authentication.AuthErrorMessage).ToNot(Equal(""))
@@ -832,7 +832,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
-			fetched := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+			fetched := &metricscfgv1beta1.MetricsConfig{}
 
 			// wait until the cluster ID is set
 			Eventually(func() bool {
@@ -840,7 +840,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 				return fetched.Status.Authentication.AuthenticationCredentialsFound != nil
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(fetched.Status.Authentication.AuthType).To(Equal(kokumetricscfgv1beta1.DefaultAuthenticationType))
+			Expect(fetched.Status.Authentication.AuthType).To(Equal(metricscfgv1beta1.DefaultAuthenticationType))
 			Expect(*fetched.Status.Authentication.AuthenticationCredentialsFound).To(BeFalse())
 			Expect(fetched.Status.Authentication.AuthErrorMessage).ToNot(Equal(""))
 			Expect(fetched.Status.Authentication.ValidBasicAuth).To(BeNil())
@@ -857,7 +857,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
-			fetched := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+			fetched := &metricscfgv1beta1.MetricsConfig{}
 
 			// wait until the cluster ID is set
 			Eventually(func() bool {
@@ -865,7 +865,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 				return fetched.Status.Authentication.AuthenticationCredentialsFound != nil
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(fetched.Status.Authentication.AuthType).To(Equal(kokumetricscfgv1beta1.DefaultAuthenticationType))
+			Expect(fetched.Status.Authentication.AuthType).To(Equal(metricscfgv1beta1.DefaultAuthenticationType))
 			Expect(*fetched.Status.Authentication.AuthenticationCredentialsFound).To(BeFalse())
 			Expect(fetched.Status.Authentication.AuthErrorMessage).ToNot(Equal(""))
 			Expect(fetched.Status.Authentication.ValidBasicAuth).To(BeNil())
@@ -879,11 +879,11 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 			instCopy := instance.DeepCopy()
 			instCopy.ObjectMeta.Name = namePrefix + "missingcvfailure"
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
-			instCopy.Spec.Authentication.AuthType = kokumetricscfgv1beta1.Basic
+			instCopy.Spec.Authentication.AuthType = metricscfgv1beta1.Basic
 			instCopy.Spec.Authentication.AuthenticationSecretName = authSecretName
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
-			fetched := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+			fetched := &metricscfgv1beta1.MetricsConfig{}
 
 			// check the CR was created ok
 			Eventually(func() bool {
@@ -907,7 +907,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
-			fetched := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+			fetched := &metricscfgv1beta1.MetricsConfig{}
 
 			// wait until the cluster ID is set
 			Eventually(func() bool {
@@ -915,7 +915,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 				return fetched.Status.Authentication.AuthenticationCredentialsFound != nil
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(fetched.Status.Authentication.AuthType).To(Equal(kokumetricscfgv1beta1.DefaultAuthenticationType))
+			Expect(fetched.Status.Authentication.AuthType).To(Equal(metricscfgv1beta1.DefaultAuthenticationType))
 			Expect(*fetched.Status.Authentication.AuthenticationCredentialsFound).To(BeTrue())
 			Expect(fetched.Status.APIURL).To(Equal(defaultAPIURL))
 			Expect(fetched.Status.ClusterID).To(Equal(clusterID))
@@ -935,7 +935,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
-			fetched := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+			fetched := &metricscfgv1beta1.MetricsConfig{}
 
 			// wait until the cluster ID is set
 			Eventually(func() bool {
@@ -943,7 +943,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 				return fetched.Status.Authentication.AuthenticationCredentialsFound != nil
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(fetched.Status.Authentication.AuthType).To(Equal(kokumetricscfgv1beta1.DefaultAuthenticationType))
+			Expect(fetched.Status.Authentication.AuthType).To(Equal(metricscfgv1beta1.DefaultAuthenticationType))
 			Expect(*fetched.Status.Authentication.AuthenticationCredentialsFound).To(BeTrue())
 			Expect(fetched.Status.APIURL).To(Equal(validTS.URL))
 			Expect(fetched.Status.ClusterID).To(Equal(clusterID))
@@ -971,12 +971,12 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 			instCopy := instance.DeepCopy()
 			instCopy.ObjectMeta.Name = namePrefix + "attemptupload-unauthorized"
 			instCopy.Spec.APIURL = unauthorizedTS.URL
-			instCopy.Spec.Authentication.AuthType = kokumetricscfgv1beta1.Basic
+			instCopy.Spec.Authentication.AuthType = metricscfgv1beta1.Basic
 			instCopy.Spec.Authentication.AuthenticationSecretName = authSecretName
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
-			fetched := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+			fetched := &metricscfgv1beta1.MetricsConfig{}
 
 			// wait until the cluster ID is set
 			Eventually(func() bool {
@@ -984,7 +984,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 				return fetched.Status.Authentication.AuthenticationCredentialsFound != nil
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(fetched.Status.Authentication.AuthType).To(Equal(kokumetricscfgv1beta1.Basic))
+			Expect(fetched.Status.Authentication.AuthType).To(Equal(metricscfgv1beta1.Basic))
 			Expect(*fetched.Status.Authentication.AuthenticationCredentialsFound).To(BeTrue())
 			Expect(fetched.Status.Authentication.AuthErrorMessage).ToNot(Equal(""))
 			Expect(*fetched.Status.Authentication.ValidBasicAuth).To(BeFalse())
@@ -1003,7 +1003,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
-			fetched := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+			fetched := &metricscfgv1beta1.MetricsConfig{}
 
 			// wait until the cluster ID is set
 			Eventually(func() bool {
@@ -1017,7 +1017,7 @@ var _ = Describe("KokuMetricsConfigController - CRD Handling", func() {
 				return fetched.Status.Upload.LastSuccessfulUploadTime.IsZero()
 			}, timeout, interval).ShouldNot(BeTrue())
 
-			Expect(fetched.Status.Authentication.AuthType).To(Equal(kokumetricscfgv1beta1.DefaultAuthenticationType))
+			Expect(fetched.Status.Authentication.AuthType).To(Equal(metricscfgv1beta1.DefaultAuthenticationType))
 			Expect(*fetched.Status.Authentication.AuthenticationCredentialsFound).To(BeTrue())
 			Expect(fetched.Status.APIURL).To(Equal(defaultAPIURL))
 			Expect(fetched.Status.ClusterID).To(Equal(clusterID))

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -34,7 +34,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kokumetricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
+	metricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
 	"github.com/project-koku/koku-metrics-operator/testutils"
 	// +kubebuilder:scaffold:imports
 )
@@ -180,7 +180,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).ToNot(BeNil())
 
-	err = kokumetricscfgv1beta1.AddToScheme(scheme.Scheme)
+	err = metricscfgv1beta1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = configv1.AddToScheme(scheme.Scheme)
@@ -204,7 +204,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	if !useCluster {
-		err = (&KokuMetricsConfigReconciler{
+		err = (&MetricsConfigReconciler{
 			Client:                        k8sManager.GetClient(),
 			Scheme:                        scheme.Scheme,
 			Clientset:                     clientset,

--- a/crhchttp/config.go
+++ b/crhchttp/config.go
@@ -8,14 +8,14 @@ package crhchttp
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kokumetricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
+	metricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
 )
 
 // AuthConfig provides the data for reconciling the CR with defaults
 type AuthConfig struct {
 	Client            client.Client
 	ClusterID         string
-	Authentication    kokumetricscfgv1beta1.AuthenticationType
+	Authentication    metricscfgv1beta1.AuthenticationType
 	BearerTokenString string
 	BasicAuthUser     string
 	BasicAuthPassword string

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 
-	kokumetricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
+	metricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
 	"github.com/project-koku/koku-metrics-operator/controllers"
 	// +kubebuilder:scaffold:imports
 )
@@ -35,8 +35,8 @@ func init() {
 
 	// Adding the configv1 scheme
 	utilruntime.Must(configv1.AddToScheme(scheme))
-	// Adding the kokumetricscfgv1beta1 scheme
-	utilruntime.Must(kokumetricscfgv1beta1.AddToScheme(scheme))
+	// Adding the metricscfgv1beta1 scheme
+	utilruntime.Must(metricscfgv1beta1.AddToScheme(scheme))
 	// Adding the operatorsv1alpha1 scheme
 	utilruntime.Must(operatorsv1alpha1.AddToScheme(scheme))
 
@@ -84,14 +84,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&controllers.KokuMetricsConfigReconciler{
+	if err = (&controllers.MetricsConfigReconciler{
 		Client:    mgr.GetClient(),
 		Scheme:    mgr.GetScheme(),
 		Clientset: clientset,
 		InCluster: inCluster,
 		Namespace: watchNamespace,
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "KokuMetricsConfig")
+		setupLog.Error(err, "unable to create controller", "controller", "MetricsConfig")
 		os.Exit(1)
 	}
 

--- a/packaging/packaging.go
+++ b/packaging/packaging.go
@@ -26,14 +26,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logr "sigs.k8s.io/controller-runtime/pkg/log"
 
-	kokumetricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
+	metricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
 	"github.com/project-koku/koku-metrics-operator/dirconfig"
 	"github.com/project-koku/koku-metrics-operator/strset"
 )
 
 // FilePackager struct for defining the packaging vars
 type FilePackager struct {
-	KMCfg            *kokumetricscfgv1beta1.KokuMetricsConfig
+	KMCfg            *metricscfgv1beta1.MetricsConfig
 	DirCfg           *dirconfig.DirectoryConfig
 	manifest         manifestInfo
 	uid              string
@@ -72,15 +72,15 @@ type Manifest interface{}
 
 // manifest template
 type manifest struct {
-	UUID      string                                        `json:"uuid"`
-	ClusterID string                                        `json:"cluster_id"`
-	Version   string                                        `json:"version"`
-	Date      time.Time                                     `json:"date"`
-	Files     []string                                      `json:"files"`
-	Start     time.Time                                     `json:"start"`
-	End       time.Time                                     `json:"end"`
-	CRStatus  kokumetricscfgv1beta1.KokuMetricsConfigStatus `json:"cr_status"`
-	Certified bool                                          `json:"certified"`
+	UUID      string                                `json:"uuid"`
+	ClusterID string                                `json:"cluster_id"`
+	Version   string                                `json:"version"`
+	Date      time.Time                             `json:"date"`
+	Files     []string                              `json:"files"`
+	Start     time.Time                             `json:"start"`
+	End       time.Time                             `json:"end"`
+	CRStatus  metricscfgv1beta1.MetricsConfigStatus `json:"cr_status"`
+	Certified bool                                  `json:"certified"`
 }
 
 type FileInfoManifest manifest
@@ -114,7 +114,7 @@ func (p *FilePackager) buildLocalCSVFileList(fileList []os.FileInfo, stagingDire
 	return csvList
 }
 
-func (p *FilePackager) getManifest(archiveFiles map[int]string, filePath string, kmc kokumetricscfgv1beta1.KokuMetricsConfig) {
+func (p *FilePackager) getManifest(archiveFiles map[int]string, filePath string, kmc metricscfgv1beta1.MetricsConfig) {
 	// setup the manifest
 	manifestDate := metav1.Now()
 	var manifestFiles []string

--- a/packaging/packaging_test.go
+++ b/packaging/packaging_test.go
@@ -25,14 +25,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	kokumetricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
+	metricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
 	"github.com/project-koku/koku-metrics-operator/dirconfig"
 	"github.com/project-koku/koku-metrics-operator/testutils"
 )
 
 var testingDir string
 var dirCfg *dirconfig.DirectoryConfig = new(dirconfig.DirectoryConfig)
-var kmCfg = &kokumetricscfgv1beta1.KokuMetricsConfig{}
+var kmCfg = &metricscfgv1beta1.MetricsConfig{}
 var testPackager = FilePackager{
 	DirCfg: dirCfg,
 	KMCfg:  kmCfg,
@@ -1053,7 +1053,7 @@ func TestTrimPackages(t *testing.T) {
 			dirCfg := &dirconfig.DirectoryConfig{
 				Upload: dirconfig.Directory{Path: tmpDir2},
 			}
-			kmCfg := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+			kmCfg := &metricscfgv1beta1.MetricsConfig{}
 			kmCfg.Spec.Packaging.MaxReports = tt.maxReports
 			testPackager := FilePackager{
 				DirCfg: dirCfg,

--- a/sources/handler.go
+++ b/sources/handler.go
@@ -15,7 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logr "sigs.k8s.io/controller-runtime/pkg/log"
 
-	kokumetricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
+	metricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
 	"github.com/project-koku/koku-metrics-operator/crhchttp"
 )
 
@@ -112,7 +112,7 @@ type sourcePostReq struct {
 type SourceHandler struct {
 	APIURL string
 	Auth   *crhchttp.AuthConfig
-	Spec   kokumetricscfgv1beta1.CloudDotRedHatSourceStatus
+	Spec   metricscfgv1beta1.CloudDotRedHatSourceStatus
 }
 
 func (s *sourceGetReq) getRequest(handler *SourceHandler) ([]byte, error) {

--- a/sources/handler_test.go
+++ b/sources/handler_test.go
@@ -18,7 +18,7 @@ import (
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	kokumetricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
+	metricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
 	"github.com/project-koku/koku-metrics-operator/crhchttp"
 	"github.com/project-koku/koku-metrics-operator/testutils"
 )
@@ -28,7 +28,7 @@ var (
 	handler = &SourceHandler{
 		APIURL: "https://ci.cloud.redhat.com",
 		Auth:   auth,
-		Spec: kokumetricscfgv1beta1.CloudDotRedHatSourceStatus{
+		Spec: metricscfgv1beta1.CloudDotRedHatSourceStatus{
 			SourcesAPIPath: "/api/sources/v1.0/",
 			SourceName:     "post-source-name",
 		},

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -19,19 +19,19 @@ import (
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	logr "sigs.k8s.io/controller-runtime/pkg/log"
 
-	kokumetricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
+	metricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
 )
 
 var (
 	log   = logr.Log.WithName("storage")
 	tenGi = *resource.NewQuantity(10*1024*1024*1024, resource.BinarySI)
 	// DefaultPVC is a basic PVC
-	DefaultPVC = kokumetricscfgv1beta1.EmbeddedPersistentVolumeClaim{
+	DefaultPVC = metricscfgv1beta1.EmbeddedPersistentVolumeClaim{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "PersistentVolumeClaim",
 		},
-		EmbeddedObjectMetadata: kokumetricscfgv1beta1.EmbeddedObjectMetadata{
+		EmbeddedObjectMetadata: metricscfgv1beta1.EmbeddedObjectMetadata{
 			Name: "koku-metrics-operator-data",
 			Labels: map[string]string{
 				"application": "koku-metrics-operator",
@@ -60,7 +60,7 @@ func (v *volume) isMounted() bool {
 // Storage is a struct containing volume information
 type Storage struct {
 	Client    client.Client
-	KMCfg     *kokumetricscfgv1beta1.KokuMetricsConfig
+	KMCfg     *metricscfgv1beta1.MetricsConfig
 	Namespace string
 	PVC       *corev1.PersistentVolumeClaim
 
@@ -174,7 +174,7 @@ func (s *Storage) ConvertVolume() (bool, error) {
 }
 
 // MakeVolumeClaimTemplate produces a template to create the PVC
-func MakeVolumeClaimTemplate(e kokumetricscfgv1beta1.EmbeddedPersistentVolumeClaim, namespace string) *corev1.PersistentVolumeClaim {
+func MakeVolumeClaimTemplate(e metricscfgv1beta1.EmbeddedPersistentVolumeClaim, namespace string) *corev1.PersistentVolumeClaim {
 	return &corev1.PersistentVolumeClaim{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: e.APIVersion,
@@ -191,13 +191,13 @@ func MakeVolumeClaimTemplate(e kokumetricscfgv1beta1.EmbeddedPersistentVolumeCla
 }
 
 // MakeEmbeddedPVC produces a template to create the PVC
-func MakeEmbeddedPVC(pvc *corev1.PersistentVolumeClaim) *kokumetricscfgv1beta1.EmbeddedPersistentVolumeClaim {
-	return &kokumetricscfgv1beta1.EmbeddedPersistentVolumeClaim{
+func MakeEmbeddedPVC(pvc *corev1.PersistentVolumeClaim) *metricscfgv1beta1.EmbeddedPersistentVolumeClaim {
+	return &metricscfgv1beta1.EmbeddedPersistentVolumeClaim{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: pvc.APIVersion,
 			Kind:       pvc.Kind,
 		},
-		EmbeddedObjectMetadata: kokumetricscfgv1beta1.EmbeddedObjectMetadata{
+		EmbeddedObjectMetadata: metricscfgv1beta1.EmbeddedObjectMetadata{
 			Name: pvc.Name,
 		},
 		Spec: pvc.Spec,

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -18,7 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	kokumetricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
+	metricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
 	"github.com/project-koku/koku-metrics-operator/testutils"
 )
 
@@ -208,7 +208,7 @@ var _ = Describe("Storage Tests", func() {
 				depCp.OwnerReferences = []metav1.OwnerReference{owner}
 				Expect(k8sClient.Create(ctx, depCp)).Should(Succeed())
 
-				kmCfg := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+				kmCfg := &metricscfgv1beta1.MetricsConfig{}
 				pvc := MakeVolumeClaimTemplate(DefaultPVC, kokuMetricsCfgNamespace)
 				s := &Storage{
 					Client:    k8sClient,
@@ -229,7 +229,7 @@ var _ = Describe("Storage Tests", func() {
 				depCp.OwnerReferences = []metav1.OwnerReference{owner}
 				Expect(k8sClient.Create(ctx, depCp)).Should(Succeed())
 
-				kmCfg := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+				kmCfg := &metricscfgv1beta1.MetricsConfig{}
 				pvc := MakeVolumeClaimTemplate(DefaultPVC, kokuMetricsCfgNamespace)
 				s := &Storage{
 					Client:    k8sClient,
@@ -248,7 +248,7 @@ var _ = Describe("Storage Tests", func() {
 	Context("Deployment not owned by CSV", func() {
 		Describe("deployment does not exist", func() {
 			It("cannot find the deployment", func() {
-				kmCfg := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+				kmCfg := &metricscfgv1beta1.MetricsConfig{}
 				pvc := MakeVolumeClaimTemplate(DefaultPVC, kokuMetricsCfgNamespace)
 				s := &Storage{
 					Client: k8sClient,
@@ -265,7 +265,7 @@ var _ = Describe("Storage Tests", func() {
 			It("successfully establishes the mount", func() {
 				depCp := deployment.DeepCopy()
 				Expect(k8sClient.Create(ctx, depCp)).Should(Succeed())
-				kmCfg := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+				kmCfg := &metricscfgv1beta1.MetricsConfig{}
 				pvc := MakeVolumeClaimTemplate(DefaultPVC, kokuMetricsCfgNamespace)
 				s := &Storage{
 					Client:    k8sClient,
@@ -285,7 +285,7 @@ var _ = Describe("Storage Tests", func() {
 				depCp.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{*volMountWrong}
 				Expect(k8sClient.Create(ctx, depCp)).Should(Succeed())
 
-				kmCfg := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+				kmCfg := &metricscfgv1beta1.MetricsConfig{}
 				pvc := MakeVolumeClaimTemplate(DefaultPVC, kokuMetricsCfgNamespace)
 				s := &Storage{
 					Client:    k8sClient,
@@ -303,7 +303,7 @@ var _ = Describe("Storage Tests", func() {
 				depCp := deploymentNoVolume.DeepCopy()
 				Expect(k8sClient.Create(ctx, depCp)).Should(Succeed())
 
-				kmCfg := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+				kmCfg := &metricscfgv1beta1.MetricsConfig{}
 				pvc := MakeVolumeClaimTemplate(DefaultPVC, kokuMetricsCfgNamespace)
 				s := &Storage{
 					Client:    k8sClient,
@@ -321,7 +321,7 @@ var _ = Describe("Storage Tests", func() {
 				depCp.Spec.Template.Spec.Volumes = []corev1.Volume{*persistVC}
 				Expect(k8sClient.Create(ctx, depCp)).Should(Succeed())
 
-				kmCfg := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+				kmCfg := &metricscfgv1beta1.MetricsConfig{}
 				pvc := MakeVolumeClaimTemplate(DefaultPVC, kokuMetricsCfgNamespace)
 				s := &Storage{
 					Client:    k8sClient,
@@ -342,7 +342,7 @@ var _ = Describe("Storage Tests", func() {
 				depCp.Spec.Template.Spec.Volumes = []corev1.Volume{*persistVCfake}
 				Expect(k8sClient.Create(ctx, depCp)).Should(Succeed())
 
-				kmCfg := &kokumetricscfgv1beta1.KokuMetricsConfig{}
+				kmCfg := &metricscfgv1beta1.MetricsConfig{}
 				pvc := MakeVolumeClaimTemplate(DefaultPVC, kokuMetricsCfgNamespace)
 				s := &Storage{
 					Client:    k8sClient,


### PR DESCRIPTION
Wait, why!?

When we initially did this work, we named everything upstream as `koku` and then converted it all to `cost-management` for downstream. That seems fine enough, but when it comes to converting the upstream to downstream for a release, it becomes really difficult and error prone to make sure all the appropriate name changes are made. This PR will eliminate the need for making the name changes when generating the downstream code. All we will need to do for downstream releases is make sure these are set correctly to:
```diff
// +kubebuilder:object:generate:=false
-type MetricsConfig = KokuMetricsConfig
+type MetricsConfig = CostManagementMetricsConfig

// +kubebuilder:object:generate:=false
-type MetricsConfigSpec = KokuMetricsConfigSpec
+type MetricsConfigSpec = CostManagementMetricsConfigSpec

// +kubebuilder:object:generate:=false
-type MetricsConfigStatus = KokuMetricsConfigStatus
+type MetricsConfigStatus = CostManagementMetricsConfigStatus
```

The next downstream release will also be difficult to implement all these name changes again, but once those are converted, we won't have to do it again.