### PR TITLE
variable reorg and simplification

### DIFF
--- a/api/v1beta1/groupversion_info.go
+++ b/api/v1beta1/groupversion_info.go
@@ -9,13 +9,18 @@
 package v1beta1
 
 import (
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
+	// NamePrefix is the prefix used to distinguish upstream and downstream operators
+	NamePrefix = "koku"
+
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "koku-metrics-cfg.openshift.io", Version: "v1beta1"}
+	GroupVersion = schema.GroupVersion{Group: fmt.Sprintf("%s-metrics-cfg.openshift.io", NamePrefix), Version: "v1beta1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/controllers/kokumetricsconfig_controller_test.go
+++ b/controllers/kokumetricsconfig_controller_test.go
@@ -28,13 +28,17 @@ import (
 
 	metricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
 	"github.com/project-koku/koku-metrics-operator/collector"
+	"github.com/project-koku/koku-metrics-operator/dirconfig"
 	"github.com/project-koku/koku-metrics-operator/storage"
 	"github.com/project-koku/koku-metrics-operator/testutils"
 )
 
 var (
-	namespace                   = "koku-metrics-operator"
-	namePrefix                  = "cost-test-local-"
+	namespace       = fmt.Sprintf("%s-metrics-operator", metricscfgv1beta1.NamePrefix)
+	volumeMountName = fmt.Sprintf("%s-metrics-operator-reports", metricscfgv1beta1.NamePrefix)
+	volumeClaimName = fmt.Sprintf("%s-metrics-operator-data", metricscfgv1beta1.NamePrefix)
+
+	testNamePrefix              = "cost-test-local-"
 	clusterID                   = "10e206d7-a11a-403e-b835-6cff14e98b23"
 	channel                     = "4.8-stable"
 	sourceName                  = "cluster-test"
@@ -52,6 +56,7 @@ var (
 	defaultUploadWait     int64 = 0
 	defaultMaxReports     int64 = 1
 	defaultAPIURL               = "https://not-the-real-cloud.redhat.com"
+	testingDir                  = dirconfig.MountPath
 	instance                    = metricscfgv1beta1.MetricsConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
@@ -281,7 +286,6 @@ func setup() error {
 		},
 	}
 	// setup the initial testing directory
-	testingDir := "/tmp/koku-metrics-operator-reports/"
 	if _, err := os.Stat(testingDir); os.IsNotExist(err) {
 		if err := os.MkdirAll(testingDir, os.ModePerm); err != nil {
 			return fmt.Errorf("could not create %s directory: %v", testingDir, err)
@@ -306,7 +310,7 @@ func setup() error {
 
 func shutdown() {
 	previousValidation = nil
-	os.RemoveAll("/tmp/koku-metrics-operator-reports/")
+	os.RemoveAll(dirconfig.MountPath)
 }
 
 var _ = Describe("MetricsConfigController - CRD Handling", func() {
@@ -345,7 +349,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 			createDeployment(ctx, emptyDep1)
 
 			instCopy := instance.DeepCopy()
-			instCopy.ObjectMeta.Name = namePrefix + "no-pvc-spec-1"
+			instCopy.ObjectMeta.Name = testNamePrefix + "no-pvc-spec-1"
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
 			// wait until the deployment vol has changed
@@ -353,7 +357,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 				fetched := &appsv1.Deployment{}
 				_ = k8sClient.Get(ctx, types.NamespacedName{Name: emptyDep1.Name, Namespace: namespace}, fetched)
 				return fetched.Spec.Template.Spec.Volumes[0].EmptyDir == nil &&
-					fetched.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName == "koku-metrics-operator-data"
+					fetched.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName == volumeClaimName
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(k8sClient.Delete(ctx, instCopy)).To(Succeed())
@@ -361,7 +365,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 		It("should not mount PVC for CR without PVC spec - pvc already mounted", func() {
 			// reuse the old deployment
 			instCopy := instance.DeepCopy()
-			instCopy.ObjectMeta.Name = namePrefix + "no-pvc-spec-2"
+			instCopy.ObjectMeta.Name = testNamePrefix + "no-pvc-spec-2"
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
 			fetched := &metricscfgv1beta1.MetricsConfig{}
@@ -384,7 +388,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 		It("should mount PVC for CR with new PVC spec - pvc already mounted", func() {
 			// reuse the old deployment
 			instCopy := instance.DeepCopy()
-			instCopy.ObjectMeta.Name = namePrefix + "pvc-spec-3"
+			instCopy.ObjectMeta.Name = testNamePrefix + "pvc-spec-3"
 			instCopy.Spec.VolumeClaimTemplate = differentPVC
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
@@ -392,7 +396,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 			Eventually(func() bool {
 				fetched := &appsv1.Deployment{}
 				_ = k8sClient.Get(ctx, types.NamespacedName{Name: emptyDep1.Name, Namespace: namespace}, fetched)
-				return fetched.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName != "koku-metrics-operator-data"
+				return fetched.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName != volumeClaimName
 			}, timeout, interval).Should(BeTrue())
 
 			deleteDeployment(ctx, emptyDep1)
@@ -402,7 +406,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 			createDeployment(ctx, emptyDep2)
 			// reuse the old deployment
 			instCopy := instance.DeepCopy()
-			instCopy.ObjectMeta.Name = namePrefix + "pvc-spec-4"
+			instCopy.ObjectMeta.Name = testNamePrefix + "pvc-spec-4"
 			instCopy.Spec.VolumeClaimTemplate = differentPVC
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
@@ -419,7 +423,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 		It("should not mount PVC for CR without PVC spec - pvc already mounted", func() {
 			// reuse the old deployment
 			instCopy := instance.DeepCopy()
-			instCopy.ObjectMeta.Name = namePrefix + "pvc-spec-5"
+			instCopy.ObjectMeta.Name = testNamePrefix + "pvc-spec-5"
 			instCopy.Spec.VolumeClaimTemplate = differentPVC
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
@@ -447,7 +451,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 
 			instCopy := airGappedInstance.DeepCopy()
 			instCopy.Spec.APIURL = unauthorizedTS.URL
-			instCopy.ObjectMeta.Name = namePrefix + "default-cr-air-gapped-basic"
+			instCopy.ObjectMeta.Name = testNamePrefix + "default-cr-air-gapped-basic"
 			instCopy.Spec.Authentication.AuthType = metricscfgv1beta1.Basic
 			instCopy.Spec.Authentication.AuthenticationSecretName = "not-existent-secret"
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
@@ -479,7 +483,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 		It("token auth works fine", func() {
 			instCopy := airGappedInstance.DeepCopy()
 			instCopy.Spec.APIURL = unauthorizedTS.URL
-			instCopy.ObjectMeta.Name = namePrefix + "default-cr-air-gapped-token"
+			instCopy.ObjectMeta.Name = testNamePrefix + "default-cr-air-gapped-token"
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
 			fetched := &metricscfgv1beta1.MetricsConfig{}
@@ -510,7 +514,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 	Context("Process CRD resource - post PVC mount - connected cluster", func() {
 		It("default CR works fine", func() {
 			instCopy := instance.DeepCopy()
-			instCopy.ObjectMeta.Name = namePrefix + "default-cr"
+			instCopy.ObjectMeta.Name = testNamePrefix + "default-cr"
 			instCopy.Spec.APIURL = validTS.URL
 			instCopy.Spec.Source.SourceName = "INSERT-SOURCE-NAME"
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
@@ -539,7 +543,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 		It("upload set to false case", func() {
 
 			instCopy := instance.DeepCopy()
-			instCopy.ObjectMeta.Name = namePrefix + "uploadfalse"
+			instCopy.ObjectMeta.Name = testNamePrefix + "uploadfalse"
 			instCopy.Spec.Upload.UploadToggle = &falseValue
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
@@ -563,7 +567,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 		})
 		It("should find basic auth creds for good basic auth CRD case", func() {
 			instCopy := instance.DeepCopy()
-			instCopy.ObjectMeta.Name = namePrefix + "basicauthgood"
+			instCopy.ObjectMeta.Name = testNamePrefix + "basicauthgood"
 			instCopy.Spec.APIURL = validTS.URL
 			instCopy.Spec.Authentication.AuthType = metricscfgv1beta1.Basic
 			instCopy.Spec.Authentication.AuthenticationSecretName = authSecretName
@@ -589,7 +593,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 		})
 		It("should find basic auth creds for good basic auth CRD case but fail because creds are wrong", func() {
 			instCopy := instance.DeepCopy()
-			instCopy.ObjectMeta.Name = namePrefix + "basicauthgood-unauthorized"
+			instCopy.ObjectMeta.Name = testNamePrefix + "basicauthgood-unauthorized"
 			instCopy.Spec.APIURL = unauthorizedTS.URL
 			instCopy.Spec.Authentication.AuthType = metricscfgv1beta1.Basic
 			instCopy.Spec.Authentication.AuthenticationSecretName = authSecretName
@@ -616,7 +620,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 		})
 		It("should find basic auth creds for mixedcase basic auth CRD case", func() {
 			instCopy := instance.DeepCopy()
-			instCopy.ObjectMeta.Name = namePrefix + "mixed-case"
+			instCopy.ObjectMeta.Name = testNamePrefix + "mixed-case"
 			instCopy.Spec.APIURL = validTS.URL
 			instCopy.Spec.Authentication.AuthType = metricscfgv1beta1.Basic
 			instCopy.Spec.Authentication.AuthenticationSecretName = authMixedCaseName
@@ -643,7 +647,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 		It("should fail for missing basic auth token for bad basic auth CRD case", func() {
 			badAuth := "bad-auth"
 			instCopy := instance.DeepCopy()
-			instCopy.ObjectMeta.Name = namePrefix + "basicauthbad"
+			instCopy.ObjectMeta.Name = testNamePrefix + "basicauthbad"
 			instCopy.Spec.Authentication.AuthType = metricscfgv1beta1.Basic
 			instCopy.Spec.Authentication.AuthenticationSecretName = badAuth
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
@@ -669,7 +673,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 		})
 		It("should reflect source name in status for source info CRD case", func() {
 			instCopy := instance.DeepCopy()
-			instCopy.ObjectMeta.Name = namePrefix + "sourceinfo"
+			instCopy.ObjectMeta.Name = testNamePrefix + "sourceinfo"
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
 			instCopy.Spec.Source.SourceName = sourceName
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
@@ -694,7 +698,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 		It("should reflect source error when attempting to create source", func() {
 
 			instCopy := instance.DeepCopy()
-			instCopy.ObjectMeta.Name = namePrefix + "sourcecreate"
+			instCopy.ObjectMeta.Name = testNamePrefix + "sourcecreate"
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
 			instCopy.Spec.Source.SourceName = sourceName
 			instCopy.Spec.Source.CreateSource = &trueValue
@@ -720,7 +724,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 		})
 		It("should fail due to bad basic auth secret", func() {
 			instCopy := instance.DeepCopy()
-			instCopy.ObjectMeta.Name = namePrefix + "badauthsecret"
+			instCopy.ObjectMeta.Name = testNamePrefix + "badauthsecret"
 			instCopy.Spec.Authentication.AuthType = metricscfgv1beta1.Basic
 			instCopy.Spec.Authentication.AuthenticationSecretName = badAuthSecretName
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
@@ -747,7 +751,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 		})
 		It("should fail due to missing pass in auth secret", func() {
 			instCopy := instance.DeepCopy()
-			instCopy.ObjectMeta.Name = namePrefix + "badpass"
+			instCopy.ObjectMeta.Name = testNamePrefix + "badpass"
 			instCopy.Spec.Authentication.AuthType = metricscfgv1beta1.Basic
 			instCopy.Spec.Authentication.AuthenticationSecretName = badAuthPassSecretName
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
@@ -774,7 +778,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 		})
 		It("should fail due to missing user in auth secret", func() {
 			instCopy := instance.DeepCopy()
-			instCopy.ObjectMeta.Name = namePrefix + "baduser"
+			instCopy.ObjectMeta.Name = testNamePrefix + "baduser"
 			instCopy.Spec.Authentication.AuthType = metricscfgv1beta1.Basic
 			instCopy.Spec.Authentication.AuthenticationSecretName = badAuthUserSecretName
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
@@ -801,7 +805,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 		})
 		It("should fail due to missing auth secret name with basic set", func() {
 			instCopy := instance.DeepCopy()
-			instCopy.ObjectMeta.Name = namePrefix + "missingname"
+			instCopy.ObjectMeta.Name = testNamePrefix + "missingname"
 			instCopy.Spec.Authentication.AuthType = metricscfgv1beta1.Basic
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
@@ -828,7 +832,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 		It("should should fail due to deleted token secret", func() {
 			deletePullSecret(ctx, openShiftConfigNamespace, fakeDockerConfig())
 			instCopy := instance.DeepCopy()
-			instCopy.ObjectMeta.Name = namePrefix + "nopullsecret"
+			instCopy.ObjectMeta.Name = testNamePrefix + "nopullsecret"
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
@@ -853,7 +857,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 			createBadPullSecret(ctx, openShiftConfigNamespace)
 
 			instCopy := instance.DeepCopy()
-			instCopy.ObjectMeta.Name = namePrefix + "nopulldata"
+			instCopy.ObjectMeta.Name = testNamePrefix + "nopulldata"
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
@@ -877,7 +881,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 		It("should fail bc of missing cluster version", func() {
 			deleteClusterVersion(ctx)
 			instCopy := instance.DeepCopy()
-			instCopy.ObjectMeta.Name = namePrefix + "missingcvfailure"
+			instCopy.ObjectMeta.Name = testNamePrefix + "missingcvfailure"
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
 			instCopy.Spec.Authentication.AuthType = metricscfgv1beta1.Basic
 			instCopy.Spec.Authentication.AuthenticationSecretName = authSecretName
@@ -903,7 +907,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 			createPullSecret(ctx, openShiftConfigNamespace, fakeDockerConfig())
 
 			instCopy := instance.DeepCopy()
-			instCopy.ObjectMeta.Name = namePrefix + "attemptupload"
+			instCopy.ObjectMeta.Name = testNamePrefix + "attemptupload"
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 
@@ -930,7 +934,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 			createPullSecret(ctx, openShiftConfigNamespace, fakeDockerConfig())
 
 			instCopy := instance.DeepCopy()
-			instCopy.ObjectMeta.Name = namePrefix + "attemptuploadsuccess"
+			instCopy.ObjectMeta.Name = testNamePrefix + "attemptuploadsuccess"
 			instCopy.Spec.APIURL = validTS.URL
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
@@ -969,7 +973,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 			}
 
 			instCopy := instance.DeepCopy()
-			instCopy.ObjectMeta.Name = namePrefix + "attemptupload-unauthorized"
+			instCopy.ObjectMeta.Name = testNamePrefix + "attemptupload-unauthorized"
 			instCopy.Spec.APIURL = unauthorizedTS.URL
 			instCopy.Spec.Authentication.AuthType = metricscfgv1beta1.Basic
 			instCopy.Spec.Authentication.AuthenticationSecretName = authSecretName
@@ -999,7 +1003,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 			Expect(err, nil)
 			uploadTime := metav1.Now()
 			instCopy := instance.DeepCopy()
-			instCopy.ObjectMeta.Name = namePrefix + "checkuploadstatus"
+			instCopy.ObjectMeta.Name = testNamePrefix + "checkuploadstatus"
 			instCopy.Spec.Upload.UploadWait = &defaultUploadWait
 			Expect(k8sClient.Create(ctx, instCopy)).Should(Succeed())
 

--- a/controllers/kokumetricsconfig_controller_test.go
+++ b/controllers/kokumetricsconfig_controller_test.go
@@ -35,6 +35,7 @@ import (
 
 var (
 	namespace       = fmt.Sprintf("%s-metrics-operator", metricscfgv1beta1.NamePrefix)
+	deploymentName  = fmt.Sprintf("%s-metrics-operator", metricscfgv1beta1.NamePrefix)
 	volumeMountName = fmt.Sprintf("%s-metrics-operator-reports", metricscfgv1beta1.NamePrefix)
 	volumeClaimName = fmt.Sprintf("%s-metrics-operator-data", metricscfgv1beta1.NamePrefix)
 
@@ -310,7 +311,7 @@ func setup() error {
 
 func shutdown() {
 	previousValidation = nil
-	os.RemoveAll(dirconfig.MountPath)
+	os.RemoveAll(testingDir)
 }
 
 var _ = Describe("MetricsConfigController - CRD Handling", func() {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -53,7 +53,6 @@ var (
 	cancel             context.CancelFunc
 	useCluster         bool
 	secretsPath        = ""
-	deploymentName     = fmt.Sprintf("%s-metrics-operator", testNamePrefix)
 	emptyDirDeployment = &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      deploymentName,

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -35,6 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	metricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
+	"github.com/project-koku/koku-metrics-operator/dirconfig"
 	"github.com/project-koku/koku-metrics-operator/testutils"
 	// +kubebuilder:scaffold:imports
 )
@@ -52,9 +53,10 @@ var (
 	cancel             context.CancelFunc
 	useCluster         bool
 	secretsPath        = ""
+	deploymentName     = fmt.Sprintf("%s-metrics-operator", testNamePrefix)
 	emptyDirDeployment = &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "koku-metrics-operator",
+			Name:      deploymentName,
 			Namespace: namespace,
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -77,13 +79,13 @@ var (
 							Image: "nginx:1.12",
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "koku-metrics-operator-reports",
-									MountPath: "/tmp/koku-metrics-operator-reports",
+									Name:      volumeMountName,
+									MountPath: dirconfig.MountPath,
 								}},
 						},
 					},
 					Volumes: []corev1.Volume{{
-						Name: "koku-metrics-operator-reports",
+						Name: volumeMountName,
 						VolumeSource: corev1.VolumeSource{
 							EmptyDir: &corev1.EmptyDirVolumeSource{}}}},
 				},
@@ -92,7 +94,7 @@ var (
 	}
 	pvcDeployment = &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "koku-metrics-operator",
+			Name:      deploymentName,
 			Namespace: namespace,
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -115,15 +117,15 @@ var (
 							Image: "nginx:1.12",
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "koku-metrics-operator-reports",
-									MountPath: "/tmp/koku-metrics-operator-reports",
+									Name:      volumeMountName,
+									MountPath: dirconfig.MountPath,
 								}},
 						},
 					},
 					Volumes: []corev1.Volume{{
-						Name: "koku-metrics-operator-reports",
+						Name: volumeMountName,
 						VolumeSource: corev1.VolumeSource{
-							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "koku-metrics-operator-data"}}}},
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: volumeClaimName}}}},
 				},
 			},
 		},

--- a/dirconfig/dirconfig.go
+++ b/dirconfig/dirconfig.go
@@ -13,10 +13,13 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 	logr "sigs.k8s.io/controller-runtime/pkg/log"
+
+	metricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
 )
 
 var (
-	parentDir    = "/tmp/koku-metrics-operator-reports/"
+	MountPath = filepath.Join("tmp", fmt.Sprintf("%s-metrics-operator-reports", metricscfgv1beta1.NamePrefix))
+
 	queryDataDir = "data"
 	stagingDir   = "staging"
 	uploadDir    = "upload"
@@ -153,7 +156,7 @@ func getOrCreatePath(directory string, dirFs *DirectoryFileSystem) (*Directory, 
 func (dirCfg *DirectoryConfig) GetDirectoryConfig() error {
 	var err error
 	dirMap := map[string]*Directory{}
-	dirMap["parent"], err = getOrCreatePath(parentDir, dirCfg.DirectoryFileSystem)
+	dirMap["parent"], err = getOrCreatePath(MountPath, dirCfg.DirectoryFileSystem)
 	if err != nil {
 		return fmt.Errorf("getDirectoryConfig: %v", err)
 	}
@@ -164,7 +167,7 @@ func (dirCfg *DirectoryConfig) GetDirectoryConfig() error {
 		"upload":  uploadDir,
 	}
 	for name, folder := range folders {
-		d := filepath.Join(parentDir, folder)
+		d := filepath.Join(MountPath, folder)
 		dirMap[name], err = getOrCreatePath(d, dirCfg.DirectoryFileSystem)
 		if err != nil {
 			return fmt.Errorf("getDirectoryConfig: %v", err)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -23,7 +23,13 @@ import (
 )
 
 var (
-	log   = logr.Log.WithName("storage")
+	log = logr.Log.WithName("storage")
+
+	applicationName = fmt.Sprintf("%s-metrics-operator", metricscfgv1beta1.NamePrefix)
+	deploymentName  = fmt.Sprintf("%s-metrics-operator", metricscfgv1beta1.NamePrefix)
+	volumeMountName = fmt.Sprintf("%s-metrics-operator-reports", metricscfgv1beta1.NamePrefix)
+	volumeClaimName = fmt.Sprintf("%s-metrics-operator-data", metricscfgv1beta1.NamePrefix)
+
 	tenGi = *resource.NewQuantity(10*1024*1024*1024, resource.BinarySI)
 	// DefaultPVC is a basic PVC
 	DefaultPVC = metricscfgv1beta1.EmbeddedPersistentVolumeClaim{
@@ -32,9 +38,9 @@ var (
 			Kind:       "PersistentVolumeClaim",
 		},
 		EmbeddedObjectMetadata: metricscfgv1beta1.EmbeddedObjectMetadata{
-			Name: "koku-metrics-operator-data",
+			Name: volumeClaimName,
 			Labels: map[string]string{
-				"application": "koku-metrics-operator",
+				"application": applicationName,
 			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
@@ -83,7 +89,7 @@ func (s *Storage) getOrCreateVolume() error {
 
 func (s *Storage) getVolume(vols []corev1.Volume) error {
 	for i, v := range vols {
-		if v.Name == "koku-metrics-operator-reports" {
+		if v.Name == volumeMountName {
 			s.vol = &volume{index: i, volume: &v}
 			if v.EmptyDir != nil {
 				s.CR.Status.Storage.VolumeType = v.EmptyDir.String()
@@ -132,7 +138,7 @@ func (s *Storage) ConvertVolume() (bool, error) {
 	deployment := &appsv1.Deployment{}
 	namespace := types.NamespacedName{
 		Namespace: s.Namespace,
-		Name:      "koku-metrics-operator"}
+		Name:      deploymentName}
 	if err := s.Client.Get(ctx, namespace, deployment); err != nil {
 		return false, fmt.Errorf("unable to get Deployment: %v", err)
 	}

--- a/storage/suite_test.go
+++ b/storage/suite_test.go
@@ -72,7 +72,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())
 
-	createNamespace(kokuMetricsCfgNamespace)
+	createNamespace(namespace)
 }, 60)
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
This PR builds on https://github.com/project-koku/koku-metrics-operator/pull/161. Move the prefix `koku` to the API directory so that it can be imported elsewhere. When we need to change `koku` to `costmanagement`, we will only need to update one place instead of many.