### PR TITLE
read ConfigMap directly from api-server

### DIFF
--- a/controllers/kokumetricsconfig_controller.go
+++ b/controllers/kokumetricsconfig_controller.go
@@ -67,6 +67,7 @@ type MetricsConfigReconciler struct {
 	InCluster bool
 	Namespace string
 
+	apiReader                     client.Reader
 	cvClientBuilder               cv.ClusterVersionBuilder
 	promCollector                 *collector.PrometheusCollector
 	disablePreviousDataCollection bool
@@ -750,6 +751,7 @@ func (r *MetricsConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 // SetupWithManager Setup reconciliation with manager object
 func (r *MetricsConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.apiReader = mgr.GetAPIReader()
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&metricscfgv1beta1.MetricsConfig{}).
 		Complete(r)

--- a/controllers/prometheus.go
+++ b/controllers/prometheus.go
@@ -44,7 +44,13 @@ func setRetentionPeriod(ctx context.Context, r *MetricsConfigReconciler) {
 	retentionPeriod = fourteenDayDuration
 
 	var configMap corev1.ConfigMap
-	if err := r.Get(ctx, monitoringMeta, &configMap); err != nil {
+	// Here we use k8s APIReader to read the k8s object by making the
+	// direct call to k8s apiserver instead of using k8sClient.
+	// The reason is that k8sClient uses a cache and we cant populate the cache
+	// with openshift-monitoring resources without some custom cache func.
+	// It is okay to make direct call to k8s apiserver because we are only
+	// making single read call once per CR installation.
+	if err := r.apiReader.Get(ctx, monitoringMeta, &configMap); err != nil {
 		log.Info(fmt.Sprintf("monitoring configMap not found. defaulting retention to: %s", retentionPeriod))
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -18,7 +18,6 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	metricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
@@ -78,7 +77,6 @@ func main() {
 		LeaderElection:     enableLeaderElection,
 		LeaderElectionID:   "91c624a5.openshift.io",
 		Namespace:          watchNamespace,
-		NewCache:           cache.MultiNamespacedCacheBuilder([]string{"openshift-monitoring", watchNamespace}),
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/packaging/packaging.go
+++ b/packaging/packaging.go
@@ -461,13 +461,18 @@ func (p *FilePackager) PackageReports() error {
 	// get the start and end dates from the report
 	log.Info("getting the start and end intervals for the manifest")
 	for _, file := range filesToPackage {
-		if strings.Contains(file.Name(), "pod") {
-			absPath := filepath.Join(p.DirCfg.Staging.Path, file.Name())
+		absPath := filepath.Join(p.DirCfg.Staging.Path, file.Name())
+		if strings.Contains(file.Name(), "cm-openshift-pod") {
+			if err := p.getStartEnd(absPath); err != nil {
+				return fmt.Errorf("PackageReports: %v", err)
+			}
+		} else if p.start.IsZero() && strings.Contains(file.Name(), "ros-openshift") {
 			if err := p.getStartEnd(absPath); err != nil {
 				return fmt.Errorf("PackageReports: %v", err)
 			}
 		}
 	}
+
 	// check if the files need to be split
 	log.Info("checking to see if the report files need to be split")
 	filesToPackage, split, err := p.splitFiles(p.DirCfg.Staging.Path, filesToPackage)


### PR DESCRIPTION
* use APIReader to get the openshift-monitoring configMap directly from the api-server instead of from cache. Since the operator is namespaced, it is not easy or straightforward to add other namespaced resource (e.g. ConfigMaps) to the cache. Since we only read this configMap once during the lifetime of the CR, we do not need to worry about making too many requests against the api-server
* Set the start and end dates in the manifest from the ROS report if the Pod report does not exist.