### PR TITLE
add more logic to prevent resetting the packaging time

### DIFF
--- a/controllers/kokumetricsconfig_controller.go
+++ b/controllers/kokumetricsconfig_controller.go
@@ -691,7 +691,7 @@ func (r *MetricsConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	r.initialDataCollection = false
 	packager.FilesAction = packaging.CopyFiles
-	if endTime.Hour() == HOURS_IN_DAY {
+	if endTime.Hour() == HOURS_IN_DAY && cr.Status.Packaging.LastSuccessfulPackagingTime.Hour() != HOURS_IN_DAY {
 		// when we've reached the end of the day, force packaging to occur to generate the daily report
 		log.Info("collected a full day of data, resetting packaging time to force packaging")
 		cr.Status.Packaging.LastSuccessfulPackagingTime = metav1.Time{}

--- a/controllers/kokumetricsconfig_controller.go
+++ b/controllers/kokumetricsconfig_controller.go
@@ -682,8 +682,6 @@ func (r *MetricsConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		if r.initialDataCollection && t.Sub(startTime).Hours() == 96 {
 			// only perform these steps during the initial data collection.
 			// after collecting 96 hours of data, package the report to compress the files
-			// packaging is guarded by this LastSuccessfulPackagingTime, so setting it to
-			// zero enables packaging to occur thruout this loop
 			log.Info("collected 96 hours of data, packaging files")
 			forcePackageFiles(packager, cr)
 			startTime = t

--- a/controllers/kokumetricsconfig_controller.go
+++ b/controllers/kokumetricsconfig_controller.go
@@ -695,8 +695,7 @@ func (r *MetricsConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	r.initialDataCollection = false
 	packager.FilesAction = packaging.CopyFiles
 	if endTime.Hour() == HOURS_IN_DAY {
-		// when we've reached the end of the day, force packaging to occur to generate the daily report
-		log.Info("collected a full day of data, resetting packaging time to force packaging")
+		// when we've reached the end of the day. move the files so we stop appending to them
 		packager.FilesAction = packaging.MoveFiles
 		forcePackageFiles(packager, cr)
 	} else {

--- a/controllers/kokumetricsconfig_controller.go
+++ b/controllers/kokumetricsconfig_controller.go
@@ -428,16 +428,6 @@ func checkSource(r *MetricsConfigReconciler, handler *sources.SourceHandler, cr 
 	}
 }
 
-func forcePackageFiles(p *packaging.FilePackager, cr *metricscfgv1beta1.MetricsConfig) {
-	// Package and split the payload if necessary
-	cr.Status.Packaging.PackagingError = ""
-	if err := p.PackageReports(cr); err != nil {
-		log.Error(err, "PackageReports failed")
-		// update the CR packaging error status
-		cr.Status.Packaging.PackagingError = err.Error()
-	}
-}
-
 func packageFiles(p *packaging.FilePackager, cr *metricscfgv1beta1.MetricsConfig) {
 	log := log.WithName("packageAndUpload")
 
@@ -447,6 +437,16 @@ func packageFiles(p *packaging.FilePackager, cr *metricscfgv1beta1.MetricsConfig
 	}
 
 	forcePackageFiles(p, cr)
+}
+
+func forcePackageFiles(p *packaging.FilePackager, cr *metricscfgv1beta1.MetricsConfig) {
+	// Package and split the payload if necessary
+	cr.Status.Packaging.PackagingError = ""
+	if err := p.PackageReports(cr); err != nil {
+		log.Error(err, "PackageReports failed")
+		// update the CR packaging error status
+		cr.Status.Packaging.PackagingError = err.Error()
+	}
 }
 
 func uploadFiles(r *MetricsConfigReconciler, authConfig *crhchttp.AuthConfig, cr *metricscfgv1beta1.MetricsConfig, dirCfg *dirconfig.DirectoryConfig, packager *packaging.FilePackager) error {

--- a/controllers/kokumetricsconfig_controller_test.go
+++ b/controllers/kokumetricsconfig_controller_test.go
@@ -1234,7 +1234,6 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 			mockpconn.EXPECT().Query(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(model.Vector{}, nil, nil).AnyTimes()
 
 			instCopy.Spec.Upload.UploadToggle = &falseValue
-			instCopy.Status.Packaging.LastSuccessfulPackagingTime = metav1.Now()
 			createObject(ctx, instCopy)
 
 			fetched := &metricscfgv1beta1.MetricsConfig{}

--- a/packaging/packaging.go
+++ b/packaging/packaging.go
@@ -430,7 +430,7 @@ func (p *FilePackager) needSplit(fileList []os.FileInfo) bool {
 // moveOrCopyFiles moves files from reportsDirectory to stagingDirectory
 func (p *FilePackager) moveOrCopyFiles(cr *metricscfgv1beta1.MetricsConfig) ([]os.FileInfo, error) {
 	log := log.WithName("moveOrCopyFiles")
-	var movedFiles []os.FileInfo
+	var files []os.FileInfo
 
 	// move all files
 	fileList, err := ioutil.ReadDir(p.DirCfg.Reports.Path)
@@ -450,7 +450,7 @@ func (p *FilePackager) moveOrCopyFiles(cr *metricscfgv1beta1.MetricsConfig) ([]o
 		}
 	}
 
-	log.Info("moving report files to staging directory")
+	log.Info("moving or copying report files to staging directory")
 	for _, file := range fileList {
 		if !strings.HasSuffix(file.Name(), ".csv") {
 			continue
@@ -467,9 +467,9 @@ func (p *FilePackager) moveOrCopyFiles(cr *metricscfgv1beta1.MetricsConfig) ([]o
 		if err != nil {
 			return nil, fmt.Errorf("moveOrCopyFiles: failed to get new file stats: %v", err)
 		}
-		movedFiles = append(movedFiles, newFile)
+		files = append(files, newFile)
 	}
-	return movedFiles, nil
+	return files, nil
 }
 
 func (p *FilePackager) TrimPackages(cr *metricscfgv1beta1.MetricsConfig) error {
@@ -537,6 +537,7 @@ func (p *FilePackager) PackageReports(cr *metricscfgv1beta1.MetricsConfig) error
 	// move CSV reports from data directory to staging directory
 	filesToPackage, err := p.moveOrCopyFiles(cr)
 	if err == ErrNoReports {
+		log.Info("no reports to generate")
 		return nil
 	} else if err != nil {
 		return fmt.Errorf("PackageReports: %v", err)

--- a/packaging/packaging.go
+++ b/packaging/packaging.go
@@ -537,7 +537,7 @@ func (p *FilePackager) PackageReports(cr *metricscfgv1beta1.MetricsConfig) error
 	// move CSV reports from data directory to staging directory
 	filesToPackage, err := p.moveOrCopyFiles(cr)
 	if err == ErrNoReports {
-		log.Info("no reports to generate")
+		log.Info("no payload to generate")
 		return nil
 	} else if err != nil {
 		return fmt.Errorf("PackageReports: %v", err)


### PR DESCRIPTION
* don't reset the LastSuccessfulPackagingTime as a mechanism for forcing packaging
  * separate out the bit that actually does the packaging into `func forcePackageFiles` and call this directly
  * the original `packageFiles` func calls `forcePackageFiles` after it's done the cycle check
* use a new variable `newInstall` to determine if we need to force a packaging after an upgraded operator
