### PR TITLE
[COST-3758] retry failed operator queries up to 5 times

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ OS = $(shell go env GOOS)
 ARCH = $(shell go env GOARCH)
 
 DOCKER := $(shell which docker 2>/dev/null)
-# export DOCKER_DEFAULT_PLATFORM = linux/x86_64
+export DOCKER_DEFAULT_PLATFORM = linux/x86_64
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of:"

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ OS = $(shell go env GOOS)
 ARCH = $(shell go env GOARCH)
 
 DOCKER := $(shell which docker 2>/dev/null)
-export DOCKER_DEFAULT_PLATFORM = linux/x86_64
+# export DOCKER_DEFAULT_PLATFORM = linux/x86_64
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of:"
@@ -268,6 +268,7 @@ else
 KUSTOMIZE=$(shell which kustomize)
 endif
 
+NAMESPACE ?= ""
 # Generate bundle manifests and metadata, then validate generated files.
 bundle: manifests kustomize
 	mkdir -p koku-metrics-operator/$(VERSION)/
@@ -278,7 +279,7 @@ bundle: manifests kustomize
 	operator-sdk bundle validate ./bundle
 	cp -r ./bundle/ koku-metrics-operator/$(VERSION)/
 	cp bundle.Dockerfile koku-metrics-operator/$(VERSION)/Dockerfile
-	scripts/txt_replace.py $(VERSION) $(PREVIOUS_VERSION) ${IMAGE_SHA}
+	scripts/txt_replace.py $(VERSION) $(PREVIOUS_VERSION) ${IMAGE_SHA} --namespace=${NAMESPACE}
 
 # Build the bundle image.
 bundle-build:

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -194,7 +194,7 @@ func GenerateReports(cr *metricscfgv1beta1.MetricsConfig, dirCfg *dirconfig.Dire
 	// ################################################################################################################
 	log.Info("querying for node metrics")
 	nodeResults := mappedResults{}
-	if err := c.getQueryRangeResults(nodeQueries, &nodeResults, 5); err != nil {
+	if err := c.getQueryRangeResults(nodeQueries, &nodeResults, MaxRetries); err != nil {
 		return err
 	}
 
@@ -274,7 +274,7 @@ func generateCostManagementReports(log gologr.Logger, c *PrometheusCollector, di
 
 	log.Info("querying for pod metrics")
 	podResults := mappedResults{}
-	if err := c.getQueryRangeResults(podQueries, &podResults, 5); err != nil {
+	if err := c.getQueryRangeResults(podQueries, &podResults, MaxRetries); err != nil {
 		return err
 	}
 
@@ -314,7 +314,7 @@ func generateCostManagementReports(log gologr.Logger, c *PrometheusCollector, di
 
 	log.Info("querying for storage metrics")
 	volResults := mappedResults{}
-	if err := c.getQueryRangeResults(volQueries, &volResults, 5); err != nil {
+	if err := c.getQueryRangeResults(volQueries, &volResults, MaxRetries); err != nil {
 		return err
 	}
 
@@ -346,7 +346,7 @@ func generateCostManagementReports(log gologr.Logger, c *PrometheusCollector, di
 
 	log.Info("querying for namespaces")
 	namespaceResults := mappedResults{}
-	if err := c.getQueryRangeResults(namespaceQueries, &namespaceResults, 5); err != nil {
+	if err := c.getQueryRangeResults(namespaceQueries, &namespaceResults, MaxRetries); err != nil {
 		return err
 	}
 
@@ -381,7 +381,7 @@ func generateResourceOpimizationReports(log gologr.Logger, c *PrometheusCollecto
 	ts := c.TimeSeries.End
 	log.Info(fmt.Sprintf("querying for resource-optimization for ts: %+v", ts))
 	rosResults := mappedResults{}
-	if err := c.getQueryResults(ts, resourceOptimizationQueries, &rosResults, 5); err != nil {
+	if err := c.getQueryResults(ts, resourceOptimizationQueries, &rosResults, MaxRetries); err != nil {
 		return err
 	}
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -381,7 +381,7 @@ func generateResourceOpimizationReports(log gologr.Logger, c *PrometheusCollecto
 	ts := c.TimeSeries.End
 	log.Info(fmt.Sprintf("querying for resource-optimization for ts: %+v", ts))
 	rosResults := mappedResults{}
-	if err := c.getQueryResults(ts, resourceOptimizationQueries, &rosResults); err != nil {
+	if err := c.getQueryResults(ts, resourceOptimizationQueries, &rosResults, 5); err != nil {
 		return err
 	}
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -194,7 +194,7 @@ func GenerateReports(cr *metricscfgv1beta1.MetricsConfig, dirCfg *dirconfig.Dire
 	// ################################################################################################################
 	log.Info("querying for node metrics")
 	nodeResults := mappedResults{}
-	if err := c.getQueryRangeResults(nodeQueries, &nodeResults); err != nil {
+	if err := c.getQueryRangeResults(nodeQueries, &nodeResults, 5); err != nil {
 		return err
 	}
 
@@ -274,7 +274,7 @@ func generateCostManagementReports(log gologr.Logger, c *PrometheusCollector, di
 
 	log.Info("querying for pod metrics")
 	podResults := mappedResults{}
-	if err := c.getQueryRangeResults(podQueries, &podResults); err != nil {
+	if err := c.getQueryRangeResults(podQueries, &podResults, 5); err != nil {
 		return err
 	}
 
@@ -314,7 +314,7 @@ func generateCostManagementReports(log gologr.Logger, c *PrometheusCollector, di
 
 	log.Info("querying for storage metrics")
 	volResults := mappedResults{}
-	if err := c.getQueryRangeResults(volQueries, &volResults); err != nil {
+	if err := c.getQueryRangeResults(volQueries, &volResults, 5); err != nil {
 		return err
 	}
 
@@ -346,7 +346,7 @@ func generateCostManagementReports(log gologr.Logger, c *PrometheusCollector, di
 
 	log.Info("querying for namespaces")
 	namespaceResults := mappedResults{}
-	if err := c.getQueryRangeResults(namespaceQueries, &namespaceResults); err != nil {
+	if err := c.getQueryRangeResults(namespaceQueries, &namespaceResults, 5); err != nil {
 		return err
 	}
 

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -270,6 +270,7 @@ func TestGenerateReportsNoCost(t *testing.T) {
 }
 
 func TestGenerateReportsQueryErrors(t *testing.T) {
+	MaxRetries = 1
 	mapResults := make(mappedMockPromResult)
 	fakeCollector := &PrometheusCollector{
 		PromConn: mockPrometheusConnection{

--- a/collector/prometheus.go
+++ b/collector/prometheus.go
@@ -239,7 +239,8 @@ func (c *PrometheusCollector) getQueryRangeResults(queries *querys, results *map
 
 	if len(queriesToRetry) > 0 {
 		retries--
-		waitTime := time.Duration(math.Pow(2, float64(MaxRetries-retries))) * time.Second
+		sleep := math.Max(math.Pow(2, float64(MaxRetries-retries)), 1)
+		waitTime := time.Duration(sleep) * time.Second
 		log.Info(fmt.Sprintf("retrying failed queries after %s seconds", waitTime))
 		time.Sleep(waitTime)
 		return c.getQueryRangeResults(&queriesToRetry, results, retries)
@@ -279,7 +280,8 @@ func (c *PrometheusCollector) getQueryResults(ts time.Time, queries *querys, res
 
 	if len(queriesToRetry) > 0 {
 		retries--
-		waitTime := time.Duration(math.Pow(2, float64(MaxRetries-retries))) * time.Second
+		sleep := math.Max(math.Pow(2, float64(MaxRetries-retries)), 1)
+		waitTime := time.Duration(sleep) * time.Second
 		log.Info(fmt.Sprintf("retrying failed queries after %s seconds", waitTime))
 		time.Sleep(waitTime)
 		return c.getQueryResults(ts, &queriesToRetry, results, retries)

--- a/collector/prometheus.go
+++ b/collector/prometheus.go
@@ -237,7 +237,7 @@ func (c *PrometheusCollector) getQueryRangeResults(queries *querys, results *map
 	if len(queriesToRetry) > 0 {
 		retries--
 		waitTime := time.Duration(5-retries) * time.Second
-		log.Info(fmt.Sprintf("retrying failed queries after %d seconds", waitTime))
+		log.Info(fmt.Sprintf("retrying failed queries after %s seconds", waitTime))
 		time.Sleep(waitTime)
 		return c.getQueryRangeResults(&queriesToRetry, results, retries)
 	}

--- a/collector/prometheus.go
+++ b/collector/prometheus.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"path/filepath"
 	"reflect"
 	"time"
@@ -26,6 +27,8 @@ const (
 	statusConnection int = iota
 	statusConfiguration
 )
+
+var MaxRetries int = 5
 
 var (
 	ps *metricscfgv1beta1.PrometheusSpec
@@ -236,7 +239,7 @@ func (c *PrometheusCollector) getQueryRangeResults(queries *querys, results *map
 
 	if len(queriesToRetry) > 0 {
 		retries--
-		waitTime := time.Duration(5-retries) * time.Second
+		waitTime := time.Duration(math.Pow(2, float64(MaxRetries-retries))) * time.Second
 		log.Info(fmt.Sprintf("retrying failed queries after %s seconds", waitTime))
 		time.Sleep(waitTime)
 		return c.getQueryRangeResults(&queriesToRetry, results, retries)
@@ -276,7 +279,7 @@ func (c *PrometheusCollector) getQueryResults(ts time.Time, queries *querys, res
 
 	if len(queriesToRetry) > 0 {
 		retries--
-		waitTime := time.Duration(5-retries) * time.Second
+		waitTime := time.Duration(math.Pow(2, float64(MaxRetries-retries))) * time.Second
 		log.Info(fmt.Sprintf("retrying failed queries after %s seconds", waitTime))
 		time.Sleep(waitTime)
 		return c.getQueryResults(ts, &queriesToRetry, results, retries)

--- a/collector/prometheus_test.go
+++ b/collector/prometheus_test.go
@@ -91,11 +91,11 @@ func (m mockPrometheusConnectionPolling) Query(ctx context.Context, query string
 	return res.value, res.warnings, err
 }
 
-func TestGetQueryResultsSuccess(t *testing.T) {
+func TestGetQueryRangeResultsSuccess(t *testing.T) {
 	c := PrometheusCollector{
 		TimeSeries: &promv1.Range{},
 	}
-	getQueryResultsErrorsTests := []struct {
+	getQueryRangeResultsSuccessTests := []struct {
 		name          string
 		queries       *querys
 		queriesResult mappedMockPromResult
@@ -197,7 +197,7 @@ func TestGetQueryResultsSuccess(t *testing.T) {
 			wantedError: nil,
 		},
 	}
-	for _, tt := range getQueryResultsErrorsTests {
+	for _, tt := range getQueryRangeResultsSuccessTests {
 		t.Run(tt.name, func(t *testing.T) {
 			c.PromConn = mockPrometheusConnection{
 				mappedResults: &tt.queriesResult,
@@ -209,18 +209,18 @@ func TestGetQueryResultsSuccess(t *testing.T) {
 				t.Errorf("got unexpected error: %v", err)
 			}
 			if !reflect.DeepEqual(got, tt.wantedResult) {
-				t.Errorf("getQueryResults got:\n\t%s\n  want:\n\t%s", got, tt.wantedResult)
+				t.Errorf("getQueryRangeResults got:\n\t%s\n  want:\n\t%s", got, tt.wantedResult)
 			}
 		})
 	}
 }
 
-func TestGetQueryResultsError(t *testing.T) {
+func TestGetQueryRangeResultsError(t *testing.T) {
 	c := PrometheusCollector{
 		ContextTimeout: defaultContextTimeout,
 		TimeSeries:     &promv1.Range{},
 	}
-	getQueryResultsErrorsTests := []struct {
+	getQueryRangeResultsErrorsTests := []struct {
 		name         string
 		queryResult  *mockPromResult
 		wantedResult mappedResults
@@ -275,7 +275,7 @@ func TestGetQueryResultsError(t *testing.T) {
 			wantedError:  errTest,
 		},
 	}
-	for _, tt := range getQueryResultsErrorsTests {
+	for _, tt := range getQueryRangeResultsErrorsTests {
 		t.Run(tt.name, func(t *testing.T) {
 			c.PromConn = mockPrometheusConnection{
 				singleResult: tt.queryResult,

--- a/collector/prometheus_test.go
+++ b/collector/prometheus_test.go
@@ -204,7 +204,7 @@ func TestGetQueryResultsSuccess(t *testing.T) {
 				t:             t,
 			}
 			got := mappedResults{}
-			err := c.getQueryRangeResults(tt.queries, &got)
+			err := c.getQueryRangeResults(tt.queries, &got, 5)
 			if tt.wantedError == nil && err != nil {
 				t.Errorf("got unexpected error: %v", err)
 			}
@@ -282,7 +282,7 @@ func TestGetQueryResultsError(t *testing.T) {
 				t:            t,
 			}
 			got := mappedResults{}
-			err := c.getQueryRangeResults(&querys{query{QueryString: "fake-query"}}, &got)
+			err := c.getQueryRangeResults(&querys{query{QueryString: "fake-query"}}, &got, 5)
 			if tt.wantedError != nil && err == nil {
 				t.Errorf("%s got: nil error, want: error", tt.name)
 			}

--- a/controllers/kokumetricsconfig_controller_test.go
+++ b/controllers/kokumetricsconfig_controller_test.go
@@ -1049,7 +1049,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 			cr := &metricscfgv1beta1.MetricsConfig{
 				Spec: metricscfgv1beta1.MetricsConfigSpec{
 					PrometheusConfig: metricscfgv1beta1.PrometheusSpec{
-						CollectPreviousData: &trueDef,
+						CollectPreviousData: &falseDef,
 					},
 				},
 				Status: metricscfgv1beta1.MetricsConfigStatus{
@@ -1064,7 +1064,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 			Expect(got).ToNot(Equal(original.Add(-fourteenDayDuration)))
 		})
 
-		FIt("check the start time on old CR - failed query more than retention period old", func() {
+		It("check the start time on old CR - failed query more than retention period old", func() {
 			// cr.Spec.PrometheusConfig.CollectPreviousData != nil &&
 			// *cr.Spec.PrometheusConfig.CollectPreviousData &&
 			// cr.Status.Prometheus.LastQuerySuccessTime.IsZero()
@@ -1074,7 +1074,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 			cr := &metricscfgv1beta1.MetricsConfig{
 				Spec: metricscfgv1beta1.MetricsConfigSpec{
 					PrometheusConfig: metricscfgv1beta1.PrometheusSpec{
-						CollectPreviousData: &trueDef,
+						CollectPreviousData: &falseDef,
 					},
 				},
 				Status: metricscfgv1beta1.MetricsConfigStatus{

--- a/controllers/kokumetricsconfig_controller_test.go
+++ b/controllers/kokumetricsconfig_controller_test.go
@@ -252,6 +252,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 		GitCommit = "1234567"
 
 		setupRequired(ctx)
+		retentionPeriod = time.Duration(0)
 
 		promConnTester = func(promcoll *collector.PrometheusCollector) error { return nil }
 		promConnSetter = func(promcoll *collector.PrometheusCollector) error {
@@ -885,7 +886,6 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 
 		BeforeEach(func() {
 			r = &MetricsConfigReconciler{Client: k8sClient, apiReader: k8sManager.GetAPIReader()}
-			retentionPeriod = time.Duration(0)
 			Expect(retentionPeriod).To(Equal(time.Duration(0)))
 		})
 		It("configMap does not exist - uses 14 days", func() {
@@ -1085,7 +1085,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 		It("2day retention period - successfully queried but there was no data on first day, but data on second", func() {
 			resetReconciler(WithSecretOverride(true))
 
-			testConfigMap.Data = map[string]string{"config.yaml": "prometheusK8s:\n  retention: 1d"}
+			testConfigMap.Data = map[string]string{"config.yaml": "prometheusK8s:\n  retention: 2d"}
 			createObject(ctx, testConfigMap)
 
 			t := time.Now().UTC().Truncate(1 * time.Hour).Add(-1 * time.Hour)
@@ -1116,7 +1116,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 			resetReconciler(WithSecretOverride(true))
 			now = func() time.Time { return time.Now().Truncate(24 * time.Hour).Add(24 * time.Hour) }
 
-			testConfigMap.Data = map[string]string{"config.yaml": "prometheusK8s:\n  retention: 1d"}
+			testConfigMap.Data = map[string]string{"config.yaml": "prometheusK8s:\n  retention: 2d"}
 			createObject(ctx, testConfigMap)
 
 			t := now().UTC().Truncate(1 * time.Hour).Add(-1 * time.Hour)

--- a/controllers/kokumetricsconfig_controller_test.go
+++ b/controllers/kokumetricsconfig_controller_test.go
@@ -268,7 +268,7 @@ func shutdown() {
 	os.RemoveAll(testingDir)
 }
 
-var _ = Describe("MetricsConfigController - CRD Handling", func() {
+var _ = Describe("MetricsConfigController - CRD Handling", Ordered, func() {
 
 	const timeout = time.Second * 60
 	const interval = time.Second * 1
@@ -287,6 +287,9 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 	ctx := context.Background()
 	emptyDep1 := emptyDirDeployment.DeepCopy()
 	emptyDep2 := emptyDirDeployment.DeepCopy()
+
+	// override MaxRetries to reduce testing time
+	collector.MaxRetries = 1
 
 	BeforeEach(func() {
 

--- a/controllers/kokumetricsconfig_controller_test.go
+++ b/controllers/kokumetricsconfig_controller_test.go
@@ -177,6 +177,47 @@ func TestConcatErrors(t *testing.T) {
 	}
 }
 
+func TestIsQueryNeeded(t *testing.T) {
+	isQueryNeededTests := []struct {
+		name  string
+		time  time.Time
+		count []int
+		want  bool
+	}{
+		{
+			name:  "time not in tracker",
+			time:  time.Now(),
+			count: []int{-1},
+			want:  true,
+		},
+		{
+			name:  "time in tracker, retry required",
+			time:  time.Now(),
+			count: []int{0, 1, 2, 3, 4},
+			want:  true,
+		},
+		{
+			name:  "time in tracker, retry count exceeded",
+			time:  time.Now(),
+			count: []int{5, 6, 7, 8, 9},
+			want:  false,
+		},
+	}
+	for _, tt := range isQueryNeededTests {
+		for _, count := range tt.count {
+			if count > -1 {
+				retryTracker[tt.time] = count
+			}
+			t.Run(tt.name, func(t *testing.T) {
+				got := isQueryNeeded(tt.time)
+				if got != tt.want {
+					t.Errorf("%s\ngot: %v\nwant: %v\n", tt.name, got, tt.want)
+				}
+			})
+		}
+	}
+}
+
 func setup() error {
 	type dirInfo struct {
 		dirName  string

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -354,13 +354,18 @@ func replaceAuthSecretData(ctx context.Context, data map[string][]byte) {
 }
 
 func createObject(ctx context.Context, obj client.Object) {
+	key := client.ObjectKeyFromObject(obj)
+	log.Info("CREATING OBJECT", "object", key)
 	Expect(k8sClient.Create(ctx, obj)).Should(Succeed())
+	log.Info("CREATED OBJECT", "object", key)
 }
 
 func deleteObject(ctx context.Context, obj client.Object) {
 	key := client.ObjectKeyFromObject(obj)
+	log.Info("DELETING OBJECT", "object", key)
 	Expect(k8sClient.Delete(ctx, obj)).Should(Or(Succeed(), Satisfy(errors.IsNotFound)))
 	Eventually(func() bool { return errors.IsNotFound(k8sClient.Get(ctx, key, obj)) }, 60, 1).Should(BeTrue())
+	log.Info("DELETED OBJECT", "object", key)
 }
 
 func ensureObjectExists(ctx context.Context, key types.NamespacedName, obj client.Object) {

--- a/scripts/txt_replace.py
+++ b/scripts/txt_replace.py
@@ -1,27 +1,32 @@
 #!/usr/bin/env python3
-
-import sys
-from datetime import datetime
+import argparse
+import pkg_resources
+import re
+from datetime import datetime, timezone
 from tempfile import mkstemp
 from shutil import move, copymode
-from os import fdopen, name, path, remove
+from os import fdopen, path, remove
 
+valid_semver = re.compile("^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$")
 
-def check_version(v_tup):
-    new, old, _ = v_tup
+def check_version(new, old):
     if new == old:
-        print("expect new and previous versions to differ:\n\tnew version: %s\n\told version:" % new, old)
-        exit()
-    split = new.split(".")
-    if len(split) != 3:
-        print("expect version format: X.Y.Z\nactual version format: %s" % new)
-        exit()
-    for value in split:
-        try:
-            int(value)
-        except ValueError:
-            print("expect version format: X.Y.Z\nactual version format: %s" % split)
-            exit()
+        print("\nexpect new and previous versions to differ:\n\tnew version: %s\n\told version:" % new, old)
+        exit(1)
+
+    if (matched_new := re.fullmatch(valid_semver, new)) and (matched_old := re.fullmatch(valid_semver, old)):
+        if pkg_resources.parse_version(new) <= pkg_resources.parse_version(old):
+            print("\nnew version must sequentially follow old version!")
+            exit(1)
+        return
+
+    print("\ninvalid version formats:")
+    if not matched_new:
+        print("\texpect new version format: X.Y.Z\n\tactual version format: %s" % new)
+    if not matched_old:
+        print("\texpect old version format: X.Y.Z\n\tactual version format: %s" % old)
+
+    exit(1)
 
 def replace(file_path, pattern, subst):
     fh, abs_path = mkstemp()
@@ -33,27 +38,29 @@ def replace(file_path, pattern, subst):
     remove(file_path)
     move(abs_path, file_path)
 
-def fix_csv(version_tuple):
-    version, previous, sha = version_tuple
+def fix_csv(version, previous_version, image_sha, namespace=""):
+
     # get the operator description from docs
     docs = open("docs/csv-description.md")
     description = "    ".join(docs.readlines())
 
     # all the replacements that will be made in the CSV
     replacements = {
-        "0001-01-01T00:00:00Z": datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
-        "INSERT-CONTAINER-IMAGE": f"{sha}",
-        "INSERT-DESCRIPTION": "|-\n    " + description,
-        "name: Red Hat": f"name: Red Hat\n  replaces: koku-metrics-operator.v{previous}",
-        "type: AllNamespaces": f"type: AllNamespaces\n  relatedImages:\n    - name: koku-metrics-operator\n      image: {sha}"
+        "0001-01-01T00:00:00Z": f"{datetime.now(timezone.utc).replace(microsecond=0).isoformat()}Z",
+        "INSERT-CONTAINER-IMAGE": f"{image_sha}",
+        "INSERT-DESCRIPTION": f"|-\n    {description}",
+        "name: Red Hat": f"name: Red Hat\n  replaces: koku-metrics-operator.v{previous_version}",
+        "type: AllNamespaces": f"type: AllNamespaces\n  relatedImages:\n    - name: koku-metrics-operator\n      image: {image_sha}",
     }
+
+    if namespace != "":
+        replacements["namespace: placeholder"] = f"namespace: {namespace}"
 
     filename = f"koku-metrics-operator/{version}/manifests/koku-metrics-operator.clusterserviceversion.yaml"
     for k,v in replacements.items():
         replace(filename, k, v)
 
-def fix_dockerfile(version_tuple):
-    version, *_ = version_tuple
+def fix_dockerfile(version):
     replacements = {
         "bundle/manifests": "manifests",
         "bundle/metadata": "metadata",
@@ -65,13 +72,17 @@ def fix_dockerfile(version_tuple):
         replace(filename, k, v)
 
 if __name__ == "__main__":
-    nargs = len(sys.argv)
-    if nargs != 4:
-        print("usage: %s VERSION PREVIOUS_VERSION IMAGE_SHA" % path.basename(sys.argv[0]))
-        exit()
+    parser = argparse.ArgumentParser(description="Script for updating the appropriate fields of the CSV",
+                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("-n", "--namespace", help="namespace used for testing")
+    parser.add_argument("version", help="New version of the CSV")
+    parser.add_argument("previous_version", help="Version of CSV being replaced")
+    parser.add_argument("image_sha", help="The image sha of the compiled operator")
+    args = parser.parse_args()
+    config = vars(args)
+    print(config)
 
-    version_tuple = sys.argv[1:]
-    check_version(version_tuple)
+    check_version(config["version"], config["previous_version"])
 
-    fix_csv(version_tuple)
-    fix_dockerfile(version_tuple)
+    fix_csv(**config)
+    fix_dockerfile(config["version"])

--- a/scripts/txt_replace.py
+++ b/scripts/txt_replace.py
@@ -38,7 +38,7 @@ def replace(file_path, pattern, subst):
     remove(file_path)
     move(abs_path, file_path)
 
-def fix_csv(version, previous_version, image_sha, namespace=""):
+def fix_csv(version, previous_version, image_sha, namespace):
 
     # get the operator description from docs
     docs = open("docs/csv-description.md")
@@ -72,17 +72,15 @@ def fix_dockerfile(version):
         replace(filename, k, v)
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Script for updating the appropriate fields of the CSV",
-                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument("-n", "--namespace", help="namespace used for testing")
+    parser = argparse.ArgumentParser(description="Script for updating the appropriate fields of the CSV")
+    parser.add_argument("-n", "--namespace", help="namespace used for testing", default="")
     parser.add_argument("version", help="New version of the CSV")
     parser.add_argument("previous_version", help="Version of CSV being replaced")
     parser.add_argument("image_sha", help="The image sha of the compiled operator")
     args = parser.parse_args()
-    config = vars(args)
-    print(config)
+    print(vars(args))
 
-    check_version(config["version"], config["previous_version"])
+    check_version(args.version, args.previous_version)
 
-    fix_csv(**config)
-    fix_dockerfile(config["version"])
+    fix_csv(args.version, args.previous_version, args.image_sha, args.namespace)
+    fix_dockerfile(args.version)


### PR DESCRIPTION
* retry a given failed query up to 5 times
* retry an entire time range up to 5 times
  * track a count of how many times a particular start time has been tried. If we've tried a range 5 times, we skip it
  * we will maintain this tracking until we've had a successful query. If a success only comes after we've upgraded an operator, we will retry as far back as possible based on the retention period and the lastquerysuccesstime.
  * If a success comes without updating the operator, then the missed data is not collected.
* update the txt_replace.py script to use argparse and accept an optional namespace argument so you can generate a CSV with that namespace so you can deploy the CSV without manually updating the namespace

With the changes to the script, I've been using this series of make commands in order to deploy the operator to a cluster:
```
make docker-build-no-test IMG=quay.io/$USERNAME/koku-metrics-operator:v$VERSION; make docker-push IMG=quay.io/$USERNAME/koku-metrics-operator:v$VERSION; make bundle IMG=quay.io/$USERNAME/koku-metrics-operator:v$VERSION NAMESPACE=koku-metrics-operator; oc apply -f koku-metrics-operator/2.0.1/manifests/koku-metrics-operator.clusterserviceversion.yaml
```

In order to deploy an operator via a CSV like this, an OperatorGroup needs to be created:
```
apiVersion: v1
kind: Namespace
metadata:
  labels:
    app: koku-metrics-operator
    control-plane: controller-manager
  name: koku-metrics-operator
---
apiVersion: operators.coreos.com/v1
kind: OperatorGroup
metadata:
  name: koku-metrics-operator
  namespace: koku-metrics-operator
spec:
  targetNamespaces:
  - koku-metrics-operator
```

I've built this little "proxy" server so that we can simulate slow queries:
https://github.com/maskarb/devfile-sample-go-basic

In the developer view of an Openshift cluster, that repo can be imported and deployed. Then KokuMetricsConfig can be updated like this:
```
  prometheus_config:
    collect_previous_data: true
    context_timeout: 10
    disable_metrics_collection_cost_management: false
    disable_metrics_collection_resource_optimization: false
    service_address: 'http://prom-test-server-koku-metrics-operator.apps-crc.testing' (this route is found in the cluster UI)
```

With this service address, the prometheus traffic will flow thru the "proxy" server and will randomly sleep for longer than 10 seconds. This will cause a timeout to occur which is visible in the operator logs. Once that query timeout occurs, that individual query will be requeued and tried again.