### PR TITLE
[COST-4080] Replace default source name with cluster-uuid if CR is not updated

### DIFF
--- a/config/samples/koku-metrics-cfg_v1beta1_kokumetricsconfig.yaml
+++ b/config/samples/koku-metrics-cfg_v1beta1_kokumetricsconfig.yaml
@@ -14,7 +14,7 @@ spec:
     disable_metrics_collection_cost_management: false
     disable_metrics_collection_resource_optimization: false
   source:
-    name: INSERT-SOURCE-NAME
+    name: null
     check_cycle: 1440
     create_source: false
   upload:

--- a/config/samples/koku-metrics-cfg_v1beta1_kokumetricsconfig.yaml
+++ b/config/samples/koku-metrics-cfg_v1beta1_kokumetricsconfig.yaml
@@ -14,7 +14,7 @@ spec:
     disable_metrics_collection_cost_management: false
     disable_metrics_collection_resource_optimization: false
   source:
-    name: null
+    name: ""
     check_cycle: 1440
     create_source: false
   upload:

--- a/controllers/kokumetricsconfig_controller.go
+++ b/controllers/kokumetricsconfig_controller.go
@@ -151,11 +151,6 @@ func ReflectSpec(r *MetricsConfigReconciler, cr *metricscfgv1beta1.MetricsConfig
 	StringReflectSpec(r, cr, &cr.Spec.Source.SourcesAPIPath, &cr.Status.Source.SourcesAPIPath, metricscfgv1beta1.DefaultSourcesPath)
 	StringReflectSpec(r, cr, &cr.Spec.Source.SourceName, &cr.Status.Source.SourceName, "")
 
-	// use cluster id as default source name
-	if cr.Status.Source.SourceName == "" {
-		cr.Status.Source.SourceName = cr.Status.ClusterID
-	}
-
 	cr.Status.Source.CreateSource = cr.Spec.Source.CreateSource
 
 	if !reflect.DeepEqual(cr.Spec.Source.CheckCycle, cr.Status.Source.CheckCycle) {
@@ -610,6 +605,12 @@ func (r *MetricsConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		log.Error(err, "failed to obtain clusterID")
 		r.updateStatusAndLogError(ctx, cr)
 		return ctrl.Result{}, err
+	}
+
+	// set cluster id as default source name
+	if cr.Status.Source.SourceName == "" {
+		log.Info("using cluster id as default source name")
+		cr.Status.Source.SourceName = cr.Status.ClusterID
 	}
 
 	log.Info("using the following inputs", "MetricsConfigConfig", cr.Status)

--- a/controllers/kokumetricsconfig_controller.go
+++ b/controllers/kokumetricsconfig_controller.go
@@ -151,6 +151,11 @@ func ReflectSpec(r *MetricsConfigReconciler, cr *metricscfgv1beta1.MetricsConfig
 	StringReflectSpec(r, cr, &cr.Spec.Source.SourcesAPIPath, &cr.Status.Source.SourcesAPIPath, metricscfgv1beta1.DefaultSourcesPath)
 	StringReflectSpec(r, cr, &cr.Spec.Source.SourceName, &cr.Status.Source.SourceName, "")
 
+	// use cluster id as default source name
+	if cr.Status.Source.SourceName == "" {
+		cr.Status.Source.SourceName = cr.Status.ClusterID
+	}
+
 	cr.Status.Source.CreateSource = cr.Spec.Source.CreateSource
 
 	if !reflect.DeepEqual(cr.Spec.Source.CheckCycle, cr.Status.Source.CheckCycle) {

--- a/controllers/kokumetricsconfig_controller_test.go
+++ b/controllers/kokumetricsconfig_controller_test.go
@@ -488,7 +488,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 			})
 			It("default CR works fine", func() {
 				instCopy.Spec.APIURL = validTS.URL
-				instCopy.Spec.Source.SourceName = "INSERT-SOURCE-NAME"
+				instCopy.Spec.Source.SourceName = ""
 				createObject(ctx, instCopy)
 
 				fetched := &metricscfgv1beta1.MetricsConfig{}
@@ -506,6 +506,8 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 				Expect(fetched.Status.OperatorCommit).To(Equal(GitCommit))
 				Expect(fetched.Status.Prometheus.ContextTimeout).To(Equal(&defaultContextTimeout))
 				Expect(*fetched.Status.Source.SourceDefined).To(BeFalse())
+				Expect(fetched.Status.Source.SourceName).ToNot(Equal(""))
+				// TODO: test for cluster id as default source name
 				Expect(fetched.Status.Source.SourceError).ToNot(Equal(""))
 				Expect(fetched.Status.Upload.UploadWait).ToNot(BeNil())
 			})

--- a/controllers/kokumetricsconfig_controller_test.go
+++ b/controllers/kokumetricsconfig_controller_test.go
@@ -506,8 +506,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", func() {
 				Expect(fetched.Status.OperatorCommit).To(Equal(GitCommit))
 				Expect(fetched.Status.Prometheus.ContextTimeout).To(Equal(&defaultContextTimeout))
 				Expect(*fetched.Status.Source.SourceDefined).To(BeFalse())
-				Expect(fetched.Status.Source.SourceName).ToNot(Equal(""))
-				// TODO: test for cluster id as default source name
+				Expect(fetched.Status.Source.SourceName).To(Equal(clusterID))
 				Expect(fetched.Status.Source.SourceError).ToNot(Equal(""))
 				Expect(fetched.Status.Upload.UploadWait).ToNot(BeNil())
 			})

--- a/docs/csv-description.md
+++ b/docs/csv-description.md
@@ -96,12 +96,12 @@ Configure the koku-metrics-operator by creating a `KokuMetricsConfig`.
             type: basic
         ```
 
-3. To configure the koku-metrics-operator to create a cost management source, in the `source` field:
-
-    * Add a `name` field with with the preferred name of the source to be created.
+3. To configure the koku-metrics-operator to create a cost management source, edit the following values in the `source` field:
+    * Replace the `name` field value with the preferred name of the source to be created.
     * Replace the `create_source` field value with `true`.
 
-    **Note:** if the source already exists, use the existing source name in the `name` field, and leave `create_source` as false. This will allow the operator to confirm the source exists.
+    **Note:** if the source already exists, replace the empty string value of the `name` field with the existing name, and leave `create_source` as false. This will allow the operator to confirm the source exists.
+
 4. If not specified, the operator will create a default PersistentVolumeClaim called `koku-metrics-operator-data` with 10Gi of storage. To configure the koku-metrics-operator to use or create a different PVC, edit the following in the spec:
     * Add the desired configuration to the `volume_claim_template` field in the spec:
 

--- a/docs/csv-description.md
+++ b/docs/csv-description.md
@@ -96,11 +96,12 @@ Configure the koku-metrics-operator by creating a `KokuMetricsConfig`.
             type: basic
         ```
 
-3. To configure the koku-metrics-operator to create a cost management source, edit the following values in the `source` field:
-    * Replace `INSERT-SOURCE-NAME` with the preferred name of the source to be created.
+3. To configure the koku-metrics-operator to create a cost management source, in the `source` field:
+
+    * Add a `name` field with with the preferred name of the source to be created.
     * Replace the `create_source` field value with `true`.
 
-    **Note:** if the source already exists, replace `INSERT-SOURCE-NAME` with the existing name, and leave `create_source` as false. This will allow the operator to confirm the source exists.
+    **Note:** if the source already exists, use the existing source name in the `name` field, and leave `create_source` as false. This will allow the operator to confirm the source exists.
 4. If not specified, the operator will create a default PersistentVolumeClaim called `koku-metrics-operator-data` with 10Gi of storage. To configure the koku-metrics-operator to use or create a different PVC, edit the following in the spec:
     * Add the desired configuration to the `volume_claim_template` field in the spec:
 

--- a/sources/handler.go
+++ b/sources/handler.go
@@ -396,7 +396,7 @@ func SourceGetOrCreate(handler *SourceHandler, client crhchttp.HTTPClient) (bool
 		return false, currentTime, err
 	}
 	if source != nil {
-		errMsg := fmt.Sprintf("This cluster may already be registered because an OpenShift source with Cluster ID %s is already registered with a different name.", handler.Auth.ClusterID)
+		errMsg := fmt.Sprintf("This cluster may already be registered because an OpenShift source with Cluster ID %s is already registered with a different name (%s).", handler.Auth.ClusterID, source.Name)
 		log.Info(errMsg)
 		return false, metav1.Now(), fmt.Errorf(errMsg)
 	}


### PR DESCRIPTION
## Jira Ticket

[COST-4080](https://issues.redhat.com/browse/COST-4080)

## Description

- Use an empty string placeholder vs `INSERT-SOURCE-NAME` in the spec source name field.
- if the spec source name value is an empty string, replace it with cluster id.