### PR TITLE
[COST-4230] make spec.authentication.token_url optional

### DIFF
--- a/api/v1beta1/metricsconfig_types.go
+++ b/api/v1beta1/metricsconfig_types.go
@@ -213,15 +213,15 @@ type CloudDotRedHatSourceSpec struct {
 	// +kubebuilder:default=`/api/sources/v1.0/`
 	SourcesAPIPath string `json:"sources_path"`
 
-	// name is the desired name of the source to create on console.redhat.com.
+	// name is the desired name of the integration to create on console.redhat.com.
 	// +optional
 	SourceName string `json:"name,omitempty"`
 
-	// create_source toggles the creation of the source on console.redhat.com.
+	// create_source toggles the creation of the integration on console.redhat.com.
 	// +kubebuilder:default=false
 	CreateSource *bool `json:"create_source"`
 
-	// check_cycle is the number of minutes between each source status check on console.redhat.com.
+	// check_cycle is the number of minutes between each integration status check on console.redhat.com.
 	// The default is 1440 min (24 hours).
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:default=1440
@@ -260,7 +260,7 @@ type KokuMetricsConfigSpec struct {
 	// PrometheusConfig is a field of KokuMetricsConfig to represent the configuration of Prometheus connection.
 	PrometheusConfig PrometheusSpec `json:"prometheus_config"`
 
-	// source represents the desired source on console.redhat.com.
+	// source represents the desired integration on console.redhat.com.
 	Source CloudDotRedHatSourceSpec `json:"source"`
 
 	// VolumeClaimTemplate is a field of KokuMetricsConfig to represent a PVC template.
@@ -368,28 +368,28 @@ type CloudDotRedHatSourceStatus struct {
 	// +optional
 	SourcesAPIPath string `json:"sources_path,omitempty"`
 
-	// name represents the name of the source that the operator attempted to create on console.redhat.com.
+	// name represents the name of the integration that the operator attempted to create on console.redhat.com.
 	// +optional
 	SourceName string `json:"name,omitempty"`
 
-	// source_defined represents whether the defined source name exists on console.redhat.com.
+	// source_defined represents whether the defined integration name exists on console.redhat.com.
 	// +optional
 	SourceDefined *bool `json:"source_defined,omitempty"`
 
-	// create_source represents the toggle used during the creation of the source on console.redhat.com.
-	// A source will not be created if upload_toggle is `false`.
+	// create_source represents the toggle used during the creation of the integration on console.redhat.com.
+	// An Integration will not be created if upload_toggle is `false`.
 	// +optional
 	CreateSource *bool `json:"create_source,omitempty"`
 
-	// error represents any errors encountered when creating the source.
+	// error represents any errors encountered when creating the integration.
 	// +optional
 	SourceError string `json:"error,omitempty"`
 
-	// last_check_time is the time that the last source status check was attempted.
+	// last_check_time is the time that the last integration status check was attempted.
 	// +nullable
 	LastSourceCheckTime metav1.Time `json:"last_check_time,omitempty"`
 
-	// check_cycle is the number of minutes between each source status check on console.redhat.com.
+	// check_cycle is the number of minutes between each integration status check on console.redhat.com.
 	// The default is 1440 min (24 hours).
 	CheckCycle *int64 `json:"check_cycle,omitempty"`
 }
@@ -501,7 +501,7 @@ type KokuMetricsConfigStatus struct {
 	// Reports represents the status of report generation.
 	Reports ReportsStatus `json:"reports,omitempty"`
 
-	// source represents the observed state of the source on console.redhat.com.
+	// source represents the observed state of the integration on console.redhat.com.
 	// +optional
 	Source CloudDotRedHatSourceStatus `json:"source,omitempty"`
 

--- a/api/v1beta1/metricsconfig_types.go
+++ b/api/v1beta1/metricsconfig_types.go
@@ -98,10 +98,10 @@ type EmbeddedPersistentVolumeClaim struct {
 // AuthenticationSpec defines the desired state of Authentication object in the KokuMetricsConfigSpec.
 type AuthenticationSpec struct {
 
-	// AuthType is a field of KokuMetricsConfig to represent the authentication type to be used basic or token.
+	// AuthType is a field of KokuMetricsConfig to represent the authentication type to be used basic, service-account or token.
 	// Valid values are:
 	// - "basic" : Enables authentication using user and password from authentication secret.
-	// - "service-account" : Enables authentication using client-id and client-secret from the secret containing service account information.
+	// - "service-account" : Enables authentication using client_id and client_secret from the secret containing service account information.
 	// - "token" (default): Uses cluster token for authentication.
 	// +kubebuilder:default="token"
 	AuthType AuthenticationType `json:"type"`
@@ -270,7 +270,7 @@ type KokuMetricsConfigSpec struct {
 // AuthenticationStatus defines the desired state of Authentication object in the KokuMetricsConfigStatus.
 type AuthenticationStatus struct {
 
-	// AuthType is a field of KokuMetricsConfig to represent the authentication type to be used basic or token.
+	// AuthType is a field of KokuMetricsConfig to represent the authentication type to be used basic, service-account or token.
 	AuthType AuthenticationType `json:"type,omitempty"`
 
 	// AuthenticationSecretName is a field of KokuMetricsConfig to represent the secret with the user and password used for uploads.

--- a/api/v1beta1/metricsconfig_types.go
+++ b/api/v1beta1/metricsconfig_types.go
@@ -114,7 +114,7 @@ type AuthenticationSpec struct {
 	// TokenURL is a field of KokuMetricsConfig to represent the endpoint used to obtain the service account token.
 	// The default is `https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token`.
 	// +kubebuilder:default=`https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token`
-	TokenURL string `json:"token_url"`
+	TokenURL string `json:"token_url,omitempty"`
 }
 
 // PackagingSpec defines the desired state of the Packaging object in the KokuMetricsConfigSpec.
@@ -213,15 +213,15 @@ type CloudDotRedHatSourceSpec struct {
 	// +kubebuilder:default=`/api/sources/v1.0/`
 	SourcesAPIPath string `json:"sources_path"`
 
-	// name is the desired name of the integration to create on console.redhat.com.
+	// name is the desired name of the source to create on console.redhat.com.
 	// +optional
 	SourceName string `json:"name,omitempty"`
 
-	// create_source toggles the creation of the integration on console.redhat.com.
+	// create_source toggles the creation of the source on console.redhat.com.
 	// +kubebuilder:default=false
 	CreateSource *bool `json:"create_source"`
 
-	// check_cycle is the number of minutes between each integration status check on console.redhat.com.
+	// check_cycle is the number of minutes between each source status check on console.redhat.com.
 	// The default is 1440 min (24 hours).
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:default=1440
@@ -260,7 +260,7 @@ type KokuMetricsConfigSpec struct {
 	// PrometheusConfig is a field of KokuMetricsConfig to represent the configuration of Prometheus connection.
 	PrometheusConfig PrometheusSpec `json:"prometheus_config"`
 
-	// source represents the desired integration on console.redhat.com.
+	// source represents the desired source on console.redhat.com.
 	Source CloudDotRedHatSourceSpec `json:"source"`
 
 	// VolumeClaimTemplate is a field of KokuMetricsConfig to represent a PVC template.
@@ -368,28 +368,28 @@ type CloudDotRedHatSourceStatus struct {
 	// +optional
 	SourcesAPIPath string `json:"sources_path,omitempty"`
 
-	// name represents the name of the integration that the operator attempted to create on console.redhat.com.
+	// name represents the name of the source that the operator attempted to create on console.redhat.com.
 	// +optional
 	SourceName string `json:"name,omitempty"`
 
-	// source_defined represents whether the defined integration name exists on console.redhat.com.
+	// source_defined represents whether the defined source name exists on console.redhat.com.
 	// +optional
 	SourceDefined *bool `json:"source_defined,omitempty"`
 
-	// create_source represents the toggle used during the creation of the integration on console.redhat.com.
-	// An Integration will not be created if upload_toggle is `false`.
+	// create_source represents the toggle used during the creation of the source on console.redhat.com.
+	// A source will not be created if upload_toggle is `false`.
 	// +optional
 	CreateSource *bool `json:"create_source,omitempty"`
 
-	// error represents any errors encountered when creating the integration.
+	// error represents any errors encountered when creating the source.
 	// +optional
 	SourceError string `json:"error,omitempty"`
 
-	// last_check_time is the time that the last integration status check was attempted.
+	// last_check_time is the time that the last source status check was attempted.
 	// +nullable
 	LastSourceCheckTime metav1.Time `json:"last_check_time,omitempty"`
 
-	// check_cycle is the number of minutes between each integration status check on console.redhat.com.
+	// check_cycle is the number of minutes between each source status check on console.redhat.com.
 	// The default is 1440 min (24 hours).
 	CheckCycle *int64 `json:"check_cycle,omitempty"`
 }
@@ -501,7 +501,7 @@ type KokuMetricsConfigStatus struct {
 	// Reports represents the status of report generation.
 	Reports ReportsStatus `json:"reports,omitempty"`
 
-	// source represents the observed state of the integration on console.redhat.com.
+	// source represents the observed state of the source on console.redhat.com.
 	// +optional
 	Source CloudDotRedHatSourceStatus `json:"source,omitempty"`
 

--- a/config/crd/bases/koku-metrics-cfg.openshift.io_kokumetricsconfigs.yaml
+++ b/config/crd/bases/koku-metrics-cfg.openshift.io_kokumetricsconfigs.yaml
@@ -58,12 +58,12 @@ spec:
                   type:
                     default: token
                     description: 'AuthType is a field of KokuMetricsConfig to represent
-                      the authentication type to be used basic or token. Valid values
-                      are: - "basic" : Enables authentication using user and password
-                      from authentication secret. - "service-account" : Enables authentication
-                      using client-id and client-secret from the secret containing
-                      service account information. - "token" (default): Uses cluster
-                      token for authentication.'
+                      the authentication type to be used basic, service-account or
+                      token. Valid values are: - "basic" : Enables authentication
+                      using user and password from authentication secret. - "service-account"
+                      : Enables authentication using client_id and client_secret from
+                      the secret containing service account information. - "token"
+                      (default): Uses cluster token for authentication.'
                     enum:
                     - token
                     - basic
@@ -531,7 +531,8 @@ spec:
                     type: string
                   type:
                     description: AuthType is a field of KokuMetricsConfig to represent
-                      the authentication type to be used basic or token.
+                      the authentication type to be used basic, service-account or
+                      token.
                     enum:
                     - token
                     - basic

--- a/config/crd/bases/koku-metrics-cfg.openshift.io_kokumetricsconfigs.yaml
+++ b/config/crd/bases/koku-metrics-cfg.openshift.io_kokumetricsconfigs.yaml
@@ -70,7 +70,6 @@ spec:
                     - service-account
                     type: string
                 required:
-                - token_url
                 - type
                 type: object
               clusterID:
@@ -162,23 +161,23 @@ spec:
                 - skip_tls_verification
                 type: object
               source:
-                description: source represents the desired integration on console.redhat.com.
+                description: source represents the desired source on console.redhat.com.
                 properties:
                   check_cycle:
                     default: 1440
                     description: check_cycle is the number of minutes between each
-                      integration status check on console.redhat.com. The default
-                      is 1440 min (24 hours).
+                      source status check on console.redhat.com. The default is 1440
+                      min (24 hours).
                     format: int64
                     minimum: 0
                     type: integer
                   create_source:
                     default: false
-                    description: create_source toggles the creation of the integration
+                    description: create_source toggles the creation of the source
                       on console.redhat.com.
                     type: boolean
                   name:
-                    description: name is the desired name of the integration to create
+                    description: name is the desired name of the source to create
                       on console.redhat.com.
                     type: string
                   sources_path:
@@ -938,36 +937,36 @@ spec:
                     type: string
                 type: object
               source:
-                description: source represents the observed state of the integration
-                  on console.redhat.com.
+                description: source represents the observed state of the source on
+                  console.redhat.com.
                 properties:
                   check_cycle:
                     description: check_cycle is the number of minutes between each
-                      integration status check on console.redhat.com. The default
-                      is 1440 min (24 hours).
+                      source status check on console.redhat.com. The default is 1440
+                      min (24 hours).
                     format: int64
                     type: integer
                   create_source:
                     description: create_source represents the toggle used during the
-                      creation of the integration on console.redhat.com. An Integration
-                      will not be created if upload_toggle is `false`.
+                      creation of the source on console.redhat.com. A source will
+                      not be created if upload_toggle is `false`.
                     type: boolean
                   error:
                     description: error represents any errors encountered when creating
-                      the integration.
+                      the source.
                     type: string
                   last_check_time:
-                    description: last_check_time is the time that the last integration
+                    description: last_check_time is the time that the last source
                       status check was attempted.
                     format: date-time
                     nullable: true
                     type: string
                   name:
-                    description: name represents the name of the integration that
-                      the operator attempted to create on console.redhat.com.
+                    description: name represents the name of the source that the operator
+                      attempted to create on console.redhat.com.
                     type: string
                   source_defined:
-                    description: source_defined represents whether the defined integration
+                    description: source_defined represents whether the defined source
                       name exists on console.redhat.com.
                     type: boolean
                   sources_path:

--- a/config/crd/bases/koku-metrics-cfg.openshift.io_kokumetricsconfigs.yaml
+++ b/config/crd/bases/koku-metrics-cfg.openshift.io_kokumetricsconfigs.yaml
@@ -161,23 +161,23 @@ spec:
                 - skip_tls_verification
                 type: object
               source:
-                description: source represents the desired source on console.redhat.com.
+                description: source represents the desired integration on console.redhat.com.
                 properties:
                   check_cycle:
                     default: 1440
                     description: check_cycle is the number of minutes between each
-                      source status check on console.redhat.com. The default is 1440
-                      min (24 hours).
+                      integration status check on console.redhat.com. The default
+                      is 1440 min (24 hours).
                     format: int64
                     minimum: 0
                     type: integer
                   create_source:
                     default: false
-                    description: create_source toggles the creation of the source
+                    description: create_source toggles the creation of the integration
                       on console.redhat.com.
                     type: boolean
                   name:
-                    description: name is the desired name of the source to create
+                    description: name is the desired name of the integration to create
                       on console.redhat.com.
                     type: string
                   sources_path:
@@ -937,36 +937,36 @@ spec:
                     type: string
                 type: object
               source:
-                description: source represents the observed state of the source on
-                  console.redhat.com.
+                description: source represents the observed state of the integration
+                  on console.redhat.com.
                 properties:
                   check_cycle:
                     description: check_cycle is the number of minutes between each
-                      source status check on console.redhat.com. The default is 1440
-                      min (24 hours).
+                      integration status check on console.redhat.com. The default
+                      is 1440 min (24 hours).
                     format: int64
                     type: integer
                   create_source:
                     description: create_source represents the toggle used during the
-                      creation of the source on console.redhat.com. A source will
-                      not be created if upload_toggle is `false`.
+                      creation of the integration on console.redhat.com. An Integration
+                      will not be created if upload_toggle is `false`.
                     type: boolean
                   error:
                     description: error represents any errors encountered when creating
-                      the source.
+                      the integration.
                     type: string
                   last_check_time:
-                    description: last_check_time is the time that the last source
+                    description: last_check_time is the time that the last integration
                       status check was attempted.
                     format: date-time
                     nullable: true
                     type: string
                   name:
-                    description: name represents the name of the source that the operator
-                      attempted to create on console.redhat.com.
+                    description: name represents the name of the integration that
+                      the operator attempted to create on console.redhat.com.
                     type: string
                   source_defined:
-                    description: source_defined represents whether the defined source
+                    description: source_defined represents whether the defined integration
                       name exists on console.redhat.com.
                     type: boolean
                   sources_path:

--- a/controllers/kokumetricsconfig_controller.go
+++ b/controllers/kokumetricsconfig_controller.go
@@ -395,7 +395,7 @@ func (r *MetricsConfigReconciler) setAuthentication(ctx context.Context, authCon
 	if cr.Spec.Authentication.AuthenticationSecretName == "" {
 		// No authentication secret name set when using basic or service-account auth
 		cr.Status.Authentication.AuthenticationCredentialsFound = &falseDef
-		err := fmt.Errorf("no authentication secret name set when using basic or service-account auth")
+		err := fmt.Errorf("no authentication secret name set when using %s auth", cr.Status.Authentication.AuthType)
 		cr.Status.Authentication.AuthErrorMessage = err.Error()
 		cr.Status.Authentication.ValidBasicAuth = &falseDef
 		return err

--- a/controllers/kokumetricsconfig_controller_test.go
+++ b/controllers/kokumetricsconfig_controller_test.go
@@ -615,7 +615,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", Ordered, func() {
 				Expect(*fetched.Status.Authentication.AuthenticationCredentialsFound).To(BeFalse())
 				Expect(fetched.Status.Authentication.AuthenticationSecretName).To(BeEmpty())
 				Expect(fetched.Status.Authentication.AuthErrorMessage).ToNot(BeEmpty())
-				Expect(fetched.Status.Authentication.AuthErrorMessage).To(ContainSubstring("no authentication secret name set when using basic or service-account auth"))
+				Expect(fetched.Status.Authentication.AuthErrorMessage).To(ContainSubstring("no authentication secret name set when using service-account auth"))
 			})
 
 			It("should handle missing required fields in service account auth creds", func() {

--- a/docs/csv-description.md
+++ b/docs/csv-description.md
@@ -60,8 +60,8 @@ If these assumptions are not met, the operator will not deploy correctly. In the
 
 ## Configurable parameters:
   * `authentication`:
-    * `type: token` -> The authentication method for connecting to `console.redhat.com`. The default and preferred method is `token`. `basic` is used when the openshift-config pull-secret does not contain a token for `console.redhat.com`.
-    * `secret_name` -> The Secret used by the operator when the authentication type is `basic`. This parameter is required **only if** the authentication type is `basic`.
+    * `type: token` -> The authentication method for connecting to `console.redhat.com`. The default and preferred method is `token`. `basic` and `service-account` authentication methods are used when the openshift-config pull-secret does not contain a token for `console.redhat.com`.
+    * `secret_name` -> The Secret used by the operator when the authentication type is `basic` or `service-account`. This parameter is required **only if** the authentication type is `basic` or `service-account`.
   * `packaging`:
     * `max_reports_to_store: 30` -> The number of reports to store when configured in air-gapped mode. The default is 30, with a minimum of 1 and no maximum. When the operator is not configured in air-gapped mode, this parameter has no effect. Reports are removed as soon as they are uploaded.
     * `max_size: 100` -> The maximum size for packaged files in Megabytes prior to compression. The default is 100, with a minimum of 1 and maximum of 100.
@@ -85,19 +85,30 @@ If these assumptions are not met, the operator will not deploy correctly. In the
 ##### Configure authentication
 The default authentication for the operator is `token`. No further steps are required to configure token authentication. If `basic` is the preferred authentication method, a Secret must be created which holds username and password credentials:
 1. On the left navigation pane, select `Workloads` -> `Secrets` -> select Project: `koku-metrics-operator` -> `Create` -> `Key/Value Secret`
-2. Give the Secret a name and add 2 keys: `username` and `password` (all lowercase). The values for these keys correspond to console.redhat.com credentials.
+2. Give the Secret a name and add 2 keys (all lowercase) for the respective authentication type. The values for these keys correspond to console.redhat.com credentials:
+    * basic auth: `username` and `password`
+    * service-account auth: `client_id` and `client_secret` 
+
 3. Select `Create`.
 ##### Create the KokuMetricsConfig
 Configure the koku-metrics-operator by creating a `KokuMetricsConfig`.
 1. On the left navigation pane, select `Operators` -> `Installed Operators` -> `koku-metrics-operator` -> `KokuMetricsConfig` -> `Create Instance`.
-2. For `basic` authentication, edit the following values in the spec:
-    * Replace `authentication: type:` with `basic`.
+2. For `basic` or `service-account` authentication, edit the following values in the spec:
+    * Replace `authentication: type:` with `basic` or `service-account`.
     * Add the `secret_name` field under `authentication`, and set it equal to the name of the authentication Secret that was created above. The spec should look similar to the following:
 
+        * for basic auth type
         ```
           authentication:
             secret_name: SECRET-NAME
             type: basic
+        ```
+          
+        * for service-account auth type
+        ```
+          authentication:
+            secret_name: SECRET-NAME
+            type: service-account
         ```
 
 3. To configure the koku-metrics-operator to create a cost management integration, edit the following values in the `source` field:


### PR DESCRIPTION
- Make `spec.authentication.token_url `  optional to avoid error below during operator upgrade
```
error validating existing CRs against new CRD's schema for "kokumetricsconfigs.koku-metrics-cfg.openshift.io": error validating custom resource against new schema for KokuMetricsConfig koku-metrics-operator/kokumetricscfg-sample-v1beta1: [].spec.authentication.token_url: Required value
```