### PR TITLE
Role patch preparing for Thanos Query API RBAC settings update

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -34,6 +34,14 @@ rules:
   - secrets
   verbs:
   - get
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheuses/api
+  verbs:
+  - create
+  - get
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/controllers/kokumetricsconfig_controller.go
+++ b/controllers/kokumetricsconfig_controller.go
@@ -707,6 +707,7 @@ func (r *MetricsConfigReconciler) setAuthAndUpload(ctx context.Context, cr *metr
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,namespace=koku-metrics-operator,resources=pods;services;services/finalizers;endpoints;persistentvolumeclaims;events;configmaps;secrets;serviceaccounts,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=apps,namespace=koku-metrics-operator,resources=deployments,verbs=get;list;patch;watch
+// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheuses/api,verbs=get;create;update
 
 // Reconcile Process the MetricsConfig custom resource based on changes or requeue
 func (r *MetricsConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
The Thanos Query deployment [will be updated soon](https://github.com/openshift/cluster-monitoring-operator/pull/2136) in Cluster Monitorinng Operator. Its Oauth-proxy guarding the web port before Thanos Query will be swapped to Kube-rbac-proxy. Due to new RBAC settings, the priviledge to access the web port is determined by `get` , `create` and `update` verb on the resource `prometheuses/api`. 
The JIRA task for this change is https://issues.redhat.com/browse/MON-3379
Here is a video explaining this change: https://drive.google.com/file/d/1j-22p6H7MOm7vPpA5HmAjq4EcrX4jrpj/view?usp=drive_link
