### PR TITLE
add node affinity for multiarch clusters

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -25,6 +25,22 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - arm64
+                - ppc64le
+                - s390x
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                  - linux
       containers:
       - command:
         - /manager


### PR DESCRIPTION
This PR adds node affinity to ensure the controller is added to a node with a supported architecture. 

Reference: https://sdk.operatorframework.io/docs/advanced-topics/multi-arch/#setting-node-affinity-in-a-kubernetes-manifest
