### PR TITLE
omit `provenance` in buildx to prevent unknown manifests

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -49,5 +49,6 @@ jobs:
         with:
           context: .
           platforms: linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
+          provenance: false
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/Makefile
+++ b/Makefile
@@ -189,9 +189,9 @@ docker-push: ## Push docker image with the manager.
 PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
 .PHONY: docker-buildx
 docker-buildx: ## Build and push docker image for the manager for cross-platform support
-	- $(CONTAINER_TOOL) buildx create --name operator-builder --driver-opt image=moby/buildkit:v0.12.3
+	- $(CONTAINER_TOOL) buildx create --name operator-builder --driver-opt image=moby/buildkit:v0.12.4
 	- $(CONTAINER_TOOL) buildx use operator-builder
-	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} .
+	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --provenance=false --tag ${IMG} .
 	- $(CONTAINER_TOOL) buildx rm operator-builder
 
 ##@ Deployment


### PR DESCRIPTION
Buildx is adding attestation-manifests to the multi-arch builds, e.g.:
```
        {
            "mediaType": "application/vnd.oci.image.manifest.v1+json",
            "digest": "sha256:edebc9e147bbc5de113c296658c94be803afc87ecfd3688fdc305a279975f085",
            "size": 839,
            "annotations": {
                "vnd.docker.reference.digest": "sha256:2c8e1da6b1b4929e31e1199523879272fc7022c3761492a6df24a90e3c1e019f",
                "vnd.docker.reference.type": "attestation-manifest"
            },
            "platform": {
                "architecture": "unknown",
                "os": "unknown"
            }
        },
....
```

These aren't used for anything, so this PR removes them.

These unknown manifests are causing some validation warnings:
```
$ operator-sdk bundle validate ./bundle --select-optional name=multiarch
WARN[0016] Warning: Value koku-metrics-operator.v3.2.0: check if the CSV is missing the label (operatorframework.io/arch.<value>) for the Arch(s): ["unknown"]. Be aware that your Operator manager image ["quay.io/project-koku/koku-metrics-operator@sha256:2cde234ca9a1dcb7661cbbde065af65687e08a1654f960dc897e236691778ad7"] provides this support. Thus, it is very likely that you want to provide it and if you support more than amd64 architectures, you MUST,use the required labels for all which are supported.Otherwise, your solution cannot be listed on the cluster for these architectures 
WARN[0016] Warning: Value koku-metrics-operator.v3.2.0: check if the CSV is missing the label (operatorframework.io/os.<value>) for the OS(s): ["unknown"]. Be aware that your Operator manager image ["quay.io/project-koku/koku-metrics-operator@sha256:2cde234ca9a1dcb7661cbbde065af65687e08a1654f960dc897e236691778ad7"] provides this support. Thus, it is very likely that you want to provide it and if you support more than linux OS you MUST,use the required labels for all which are supported.Otherwise, your solution cannot be listed on the cluster for these architectures 
WARN[0016] Warning: Value koku-metrics-operator.v3.2.0: the image data indicates ["unknown/unknown" "unknown/unknown" "unknown/unknown" "unknown/unknown"] is supported for the image: "quay.io/project-koku/koku-metrics-operator@sha256:2cde234ca9a1dcb7661cbbde065af65687e08a1654f960dc897e236691778ad7", but the node affinity configuration for the image only specifies ["linux/amd64" "linux/arm64" "linux/ppc64le" "linux/s390x"] 
INFO[0016] All validation tests have completed successfully 
```
