### PR TITLE
Run github workflows CI jobs in ppc64le

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,52 @@ jobs:
           name: coverage
           path: cover.out
 
+  unit-test-ppc64le:
+    name: Unit Test ppc64le
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        platform: [ppc64le]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Display build environment
+        run: printenv
+
+      - name: Install required packages
+        run : |
+          os=linux
+          arch=${{ matrix.platform }}
+          curl -L "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_${os}_${arch}.tar.gz" | tar -xz -C /tmp/
+          sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
+          curl -L "https://github.com/etcd-io/etcd/releases/download/v3.5.11/etcd-v3.5.11-${os}-${arch}.tar.gz" | tar -xz -C /tmp/
+          sudo mv /tmp/etcd-v3.5.11-${os}-${arch}/etcd /usr/local/kubebuilder/bin
+          curl -L "https://storage.googleapis.com/kubernetes-release/release/v1.24.13/kubernetes-server-${os}-${arch}.tar.gz" | tar -xz -C /tmp/
+          sudo mv /tmp/kubernetes/server/bin/kube-apiserver /usr/local/kubebuilder/bin
+          sudo mv /tmp/kubernetes/server/bin/kubectl /usr/local/kubebuilder/bin
+
+      - name: Run tests on ${{ matrix.platform }}
+        run: >-
+          docker run
+          --rm
+          --platform linux/ppc64le
+          --mount "type=bind,src=/usr/local/kubebuilder,target=/usr/local/kubebuilder"
+          -w /build
+          golang:1.20
+          /bin/bash -ec '
+          useradd testuser;
+          chown testuser $(pwd);
+          chown testuser /home;
+          su testuser -c "git clone https://github.com/project-koku/koku-metrics-operator.git 
+          && cd koku-metrics-operator && make generate manifests && go test ./... -v -coverprofile cover.out -covermode=atomic";'
+
   coverage:
     name: Coverage
     needs: unit-tests


### PR DESCRIPTION
Runs tests in a ppc64le platform by first creating a ppc64le docker container and then running the tests as a non-root user inside the container.
Kubebuilder package for Power only provides the kubebuilder binary so etcd, kube-apiserver, and kubectl binaries are also installed and then mounted onto the docker container.