### PR TITLE
Resolve deployment upgrade with RWO PVCs

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -19,6 +19,8 @@ spec:
   selector:
     matchLabels:
       control-plane: controller-manager
+  strategy:
+    type: Recreate
   replicas: 1
   template:
     metadata:


### PR DESCRIPTION
When OLM tries to upgrade the operator, it will fail to rollout the new pod for the deployment due to RWO volume mounts.

The #141 PR resolved this by setting a preference to schedule the new pod on the name node as the existing pod. However this change was reverted in #145 for some unknown/undocumented reason.