### PR TITLE
revert codecov action upgrade

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -21,6 +21,10 @@ updates:
       ci-dependencies:
         patterns:
           - "*" # update all github-actions in single PR
+    ignore:
+      # v4 codecov is broken for dependabot updates because dependabot does not have access to secrets.
+      - dependency-name: "codecov/codecov-action"
+
 
   - package-ecosystem: "gomod"
     directory: "/"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,10 +86,8 @@ jobs:
         with:
           name: coverage
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           file: ./cover.out
           flags: unittests
           fail_ci_if_error: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
See https://github.com/codecov/feedback/issues/264

This PR reverts the codecov v4 upgrade because dependabot PRs cannot upload coverage reports.