### PR TITLE
[COST-4624] do not show progress update during initial data gather

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,11 +145,11 @@ verify-manifests: ## Verify manifests are up to date.
 ENVTEST_K8S_VERSION = 1.28.0
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -v ./... -coverprofile cover.out
 
 .PHONY: test-qemu
 test-qemu: envtest-not-local ## Run tests - specific for multiarch in github action
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST_NOT_LOCAL) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./...
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST_NOT_LOCAL) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -v ./...
 
 ##@ Build
 

--- a/Makefile
+++ b/Makefile
@@ -145,11 +145,11 @@ verify-manifests: ## Verify manifests are up to date.
 ENVTEST_K8S_VERSION = 1.28.0
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -v ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
 
 .PHONY: test-qemu
 test-qemu: envtest-not-local ## Run tests - specific for multiarch in github action
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST_NOT_LOCAL) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -v ./...
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST_NOT_LOCAL) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./...
 
 ##@ Build
 

--- a/internal/controller/kokumetricsconfig_controller.go
+++ b/internal/controller/kokumetricsconfig_controller.go
@@ -844,8 +844,6 @@ func (r *MetricsConfigReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			log.Info("collected 96 hours of data, packaging files")
 			packageFiles(packager, cr)
 			startTime = t
-			// update status to show progress
-			r.updateStatusAndLogError(ctx, cr)
 		}
 	}
 

--- a/internal/controller/kokumetricsconfig_controller_test.go
+++ b/internal/controller/kokumetricsconfig_controller_test.go
@@ -1316,41 +1316,41 @@ var _ = Describe("MetricsConfigController - CRD Handling", Ordered, func() {
 			Expect(err).To(BeNil())
 			Expect(len(files)).To(Equal(0))
 		})
-		It("8day retention period - successfully queried but there was no data on first day, but data on all remaining days", func() {
-			resetReconciler(WithSecretOverride(true))
+		// It("6day retention period - successfully queried but there was no data on first day, but data on all remaining days", func() {
+		// 	resetReconciler(WithSecretOverride(true))
 
-			testConfigMap.Data = map[string]string{"config.yaml": "prometheusK8s:\n  retention: 8d"}
-			createObject(ctx, testConfigMap)
+		// 	testConfigMap.Data = map[string]string{"config.yaml": "prometheusK8s:\n  retention: 6d"}
+		// 	createObject(ctx, testConfigMap)
 
-			t := metav1.Now().UTC().Truncate(1 * time.Hour).Add(-1 * time.Hour)
-			t2 := t.Truncate(24 * time.Hour).Add(-24 * 8 * time.Hour) // midnight 8 days ago
-			timeRangeInitial := promv1.Range{
-				Start: t2,
-				End:   t2.Add(59*time.Minute + 59*time.Second),
-				Step:  time.Minute,
-			}
-			mockpconn.EXPECT().QueryRange(gomock.Any(), gomock.Any(), timeRangeInitial, gomock.Any()).Return(model.Matrix{}, nil, nil).MinTimes(1)
-			mockpconn.EXPECT().QueryRange(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(asModelMatrix(metricjson, nodeallocatablecpucores), nil, nil).MinTimes(1)
+		// 	t := metav1.Now().UTC().Truncate(1 * time.Hour).Add(-1 * time.Hour)
+		// 	t2 := t.Truncate(24 * time.Hour).Add(-24 * 6 * time.Hour) // midnight 6 days ago
+		// 	timeRangeInitial := promv1.Range{
+		// 		Start: t2,
+		// 		End:   t2.Add(59*time.Minute + 59*time.Second),
+		// 		Step:  time.Minute,
+		// 	}
+		// 	mockpconn.EXPECT().QueryRange(gomock.Any(), gomock.Any(), timeRangeInitial, gomock.Any()).Return(model.Matrix{}, nil, nil).MinTimes(1)
+		// 	mockpconn.EXPECT().QueryRange(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(asModelMatrix(metricjson, nodeallocatablecpucores), nil, nil).MinTimes(1)
 
-			instCopy.Spec.Packaging.MaxReports = 2
-			instCopy.Spec.PrometheusConfig.CollectPreviousData = &trueDef
-			instCopy.Spec.PrometheusConfig.DisableMetricsCollectionResourceOptimization = &trueDef
-			instCopy.Spec.Upload.UploadToggle = &falseValue
-			createObject(ctx, instCopy)
+		// 	instCopy.Spec.Packaging.MaxReports = 2
+		// 	instCopy.Spec.PrometheusConfig.CollectPreviousData = &trueDef
+		// 	instCopy.Spec.PrometheusConfig.DisableMetricsCollectionResourceOptimization = &trueDef
+		// 	instCopy.Spec.Upload.UploadToggle = &falseValue
+		// 	createObject(ctx, instCopy)
 
-			fetched := &metricscfgv1beta1.MetricsConfig{}
+		// 	fetched := &metricscfgv1beta1.MetricsConfig{}
 
-			Eventually(func() bool {
-				_ = k8sClient.Get(ctx, types.NamespacedName{Name: instCopy.Name, Namespace: namespace}, fetched)
-				return fetched.Status.Prometheus.LastQuerySuccessTime.Equal(&metav1.Time{Time: t})
-			}, timeout, interval).Should(BeTrue())
+		// 	Eventually(func() bool {
+		// 		_ = k8sClient.Get(ctx, types.NamespacedName{Name: instCopy.Name, Namespace: namespace}, fetched)
+		// 		return fetched.Status.Prometheus.LastQuerySuccessTime.Equal(&metav1.Time{Time: t})
+		// 	}, timeout, interval).Should(BeTrue())
 
-			Expect(fetched.Status.Reports.DataCollected).To(BeTrue())
-			Expect(len(fetched.Status.Packaging.PackagedFiles)).To(Equal(2))
-			Expect(fetched.Status.Packaging.ReportCount).ToNot(BeNil())
-			Expect(*fetched.Status.Packaging.ReportCount).To(BeEquivalentTo(2))
+		// 	Expect(fetched.Status.Reports.DataCollected).To(BeTrue())
+		// 	Expect(len(fetched.Status.Packaging.PackagedFiles)).To(Equal(2))
+		// 	Expect(fetched.Status.Packaging.ReportCount).ToNot(BeNil())
+		// 	Expect(*fetched.Status.Packaging.ReportCount).To(BeEquivalentTo(2))
 
-		})
+		// })
 		It("query failed due to error", func() {
 			resetReconciler(WithSecretOverride(true))
 

--- a/internal/controller/kokumetricsconfig_controller_test.go
+++ b/internal/controller/kokumetricsconfig_controller_test.go
@@ -1316,41 +1316,6 @@ var _ = Describe("MetricsConfigController - CRD Handling", Ordered, func() {
 			Expect(err).To(BeNil())
 			Expect(len(files)).To(Equal(0))
 		})
-		// It("6day retention period - successfully queried but there was no data on first day, but data on all remaining days", func() {
-		// 	resetReconciler(WithSecretOverride(true))
-
-		// 	testConfigMap.Data = map[string]string{"config.yaml": "prometheusK8s:\n  retention: 6d"}
-		// 	createObject(ctx, testConfigMap)
-
-		// 	t := metav1.Now().UTC().Truncate(1 * time.Hour).Add(-1 * time.Hour)
-		// 	t2 := t.Truncate(24 * time.Hour).Add(-24 * 6 * time.Hour) // midnight 6 days ago
-		// 	timeRangeInitial := promv1.Range{
-		// 		Start: t2,
-		// 		End:   t2.Add(59*time.Minute + 59*time.Second),
-		// 		Step:  time.Minute,
-		// 	}
-		// 	mockpconn.EXPECT().QueryRange(gomock.Any(), gomock.Any(), timeRangeInitial, gomock.Any()).Return(model.Matrix{}, nil, nil).MinTimes(1)
-		// 	mockpconn.EXPECT().QueryRange(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(asModelMatrix(metricjson, nodeallocatablecpucores), nil, nil).MinTimes(1)
-
-		// 	instCopy.Spec.Packaging.MaxReports = 2
-		// 	instCopy.Spec.PrometheusConfig.CollectPreviousData = &trueDef
-		// 	instCopy.Spec.PrometheusConfig.DisableMetricsCollectionResourceOptimization = &trueDef
-		// 	instCopy.Spec.Upload.UploadToggle = &falseValue
-		// 	createObject(ctx, instCopy)
-
-		// 	fetched := &metricscfgv1beta1.MetricsConfig{}
-
-		// 	Eventually(func() bool {
-		// 		_ = k8sClient.Get(ctx, types.NamespacedName{Name: instCopy.Name, Namespace: namespace}, fetched)
-		// 		return fetched.Status.Prometheus.LastQuerySuccessTime.Equal(&metav1.Time{Time: t})
-		// 	}, timeout, interval).Should(BeTrue())
-
-		// 	Expect(fetched.Status.Reports.DataCollected).To(BeTrue())
-		// 	Expect(len(fetched.Status.Packaging.PackagedFiles)).To(Equal(2))
-		// 	Expect(fetched.Status.Packaging.ReportCount).ToNot(BeNil())
-		// 	Expect(*fetched.Status.Packaging.ReportCount).To(BeEquivalentTo(2))
-
-		// })
 		It("query failed due to error", func() {
 			resetReconciler(WithSecretOverride(true))
 
@@ -1430,6 +1395,42 @@ var _ = Describe("MetricsConfigController - CRD Handling", Ordered, func() {
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(fetched.Status.Reports.DataCollected).To(BeTrue())
+		})
+		It("8day retention period - successfully queried but there was no data on first day, but data on all remaining days", func() {
+			// slow test, always run this one last
+			resetReconciler(WithSecretOverride(true))
+
+			testConfigMap.Data = map[string]string{"config.yaml": "prometheusK8s:\n  retention: 8d"}
+			createObject(ctx, testConfigMap)
+
+			t := metav1.Now().UTC().Truncate(1 * time.Hour).Add(-1 * time.Hour)
+			t2 := t.Truncate(24 * time.Hour).Add(-24 * 8 * time.Hour) // midnight 8 days ago
+			timeRangeInitial := promv1.Range{
+				Start: t2,
+				End:   t2.Add(59*time.Minute + 59*time.Second),
+				Step:  time.Minute,
+			}
+			mockpconn.EXPECT().QueryRange(gomock.Any(), gomock.Any(), timeRangeInitial, gomock.Any()).Return(model.Matrix{}, nil, nil).MinTimes(1)
+			mockpconn.EXPECT().QueryRange(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(asModelMatrix(metricjson, nodeallocatablecpucores), nil, nil).MinTimes(1)
+
+			instCopy.Spec.Packaging.MaxReports = 2
+			instCopy.Spec.PrometheusConfig.CollectPreviousData = &trueDef
+			instCopy.Spec.PrometheusConfig.DisableMetricsCollectionResourceOptimization = &trueDef
+			instCopy.Spec.Upload.UploadToggle = &falseValue
+			createObject(ctx, instCopy)
+
+			fetched := &metricscfgv1beta1.MetricsConfig{}
+
+			Eventually(func() bool {
+				_ = k8sClient.Get(ctx, types.NamespacedName{Name: instCopy.Name, Namespace: namespace}, fetched)
+				return fetched.Status.Prometheus.LastQuerySuccessTime.Equal(&metav1.Time{Time: t})
+			}, timeout, interval).Should(BeTrue())
+
+			Expect(fetched.Status.Reports.DataCollected).To(BeTrue())
+			Expect(len(fetched.Status.Packaging.PackagedFiles)).To(Equal(2))
+			Expect(fetched.Status.Packaging.ReportCount).ToNot(BeNil())
+			Expect(*fetched.Status.Packaging.ReportCount).To(BeEquivalentTo(2))
+
 		})
 	})
 })


### PR DESCRIPTION
Updating the status during initial data gather is causing the operator to generate invalid reports.

Here is the scenario:
1. a cluster was created in the afternoon on 2-19.
2. the operator was installed on 2-20.
3. During initial data gathering, we start gathering data from 14 days ago. As we progress thru the days with no data, we set the status with the last successful query time and the message that no data was collected. Each of these status updates causes another reconciliation. 
4. While we progress thru the first reconciliation, we [do not gather the data on the 19th because it is incomplete data](https://github.com/project-koku/koku-metrics-operator/blob/main/internal/controller/kokumetricsconfig_controller.go#L829-L836).
5. We gather all of the 2-20 data and ship the payload. This data file remains on the PVC because we have not collected all of 2-20 data yet.
6. The next reconciliation starts (one of the ones that was triggered by the progress update). Let's suppose that during this reconciliation, the status was set to:
```
"last_hour_queried":"2024-02-18 00:00:00 - 2024-02-18 00:59:59","data_collection_message":"No data to report for the hour queried."
```
Because of [this logic](https://github.com/project-koku/koku-metrics-operator/blob/main/internal/controller/prometheus.go#L107), we restart gathering data from 2-18 01:00:00. This causes us to insert the 2-19 data into the report file. So now we have 2-19 data after the 2-20 data in the report files.


The simplest solution for this is to not do the status update until the full reconciliation is done. 