### PR TITLE
[COST-4528] set minimum upload_cycle to 60

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-PREVIOUS_VERSION ?= 3.1.0
-VERSION ?= 3.2.0
+PREVIOUS_VERSION ?= 3.2.0
+VERSION ?= 3.2.1
 
 MIN_KUBE_VERSION = 1.24.0
 MIN_OCP_VERSION = 4.12
@@ -270,7 +270,6 @@ get-token-and-cert:  ## Get a token from a running K8s cluster for local develop
 
 ##@ Build Bundle and Test Catalog
 
-NAMESPACE ?= ""
 .PHONY: bundle
 bundle: operator-sdk manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
 	mkdir -p koku-metrics-operator/$(VERSION)/
@@ -286,6 +285,9 @@ bundle: operator-sdk manifests kustomize ## Generate bundle manifests and metada
 	$(YQ) -i '.spec.minKubeVersion = "$(MIN_KUBE_VERSION)"' bundle/manifests/koku-metrics-operator.clusterserviceversion.yaml
 	$(YQ) -i '.spec.relatedImages = [{"name": "koku-metrics-operator", "image": "$(IMAGE_SHA)"}]' bundle/manifests/koku-metrics-operator.clusterserviceversion.yaml
 	$(YQ) -i '.spec.replaces = "koku-metrics-operator.v$(PREVIOUS_VERSION)"' bundle/manifests/koku-metrics-operator.clusterserviceversion.yaml
+ifdef NAMESPACE
+	$(YQ) -i '.metadata.namespace = "$(NAMESPACE)"' bundle/manifests/koku-metrics-operator.clusterserviceversion.yaml
+endif
 	scripts/update_bundle_dockerfile.py
 
 	cp -r ./bundle/ koku-metrics-operator/$(VERSION)/

--- a/internal/controller/kokumetricsconfig_controller.go
+++ b/internal/controller/kokumetricsconfig_controller.go
@@ -55,8 +55,9 @@ var (
 	authClientId             = "client_id"
 	authClientSecret         = "client_secret"
 
-	falseDef = false
-	trueDef  = true
+	falseDef   = false
+	trueDef    = true
+	sixtyInt64 = int64(60)
 
 	dirCfg             *dirconfig.DirectoryConfig = new(dirconfig.DirectoryConfig)
 	sourceSpec         *metricscfgv1beta1.CloudDotRedHatSourceSpec
@@ -148,6 +149,11 @@ func ReflectSpec(r *MetricsConfigReconciler, cr *metricscfgv1beta1.MetricsConfig
 		r := rand.New(rand.NewSource(time.Now().UnixNano()))
 		uploadWait := r.Int63() % 35
 		cr.Status.Upload.UploadWait = &uploadWait
+	}
+
+	// COST-4528: ensure upload_cycle is not less than 60
+	if *cr.Spec.Upload.UploadCycle < 60 {
+		cr.Spec.Upload.UploadCycle = &sixtyInt64
 	}
 
 	if !reflect.DeepEqual(cr.Spec.Upload.UploadCycle, cr.Status.Upload.UploadCycle) {

--- a/internal/controller/kokumetricsconfig_controller.go
+++ b/internal/controller/kokumetricsconfig_controller.go
@@ -55,8 +55,9 @@ var (
 	authClientId             = "client_id"
 	authClientSecret         = "client_secret"
 
-	falseDef   = false
-	trueDef    = true
+	falseDef = false
+	trueDef  = true
+
 	sixtyInt64 = int64(60)
 
 	dirCfg             *dirconfig.DirectoryConfig = new(dirconfig.DirectoryConfig)

--- a/internal/controller/kokumetricsconfig_controller_test.go
+++ b/internal/controller/kokumetricsconfig_controller_test.go
@@ -570,6 +570,20 @@ var _ = Describe("MetricsConfigController - CRD Handling", Ordered, func() {
 				Expect(fetched.Status.Upload.UploadToggle).To(Equal(&falseValue))
 				Expect(fetched.Status.Upload.UploadWait).To(Equal(&defaultUploadWait))
 			})
+			It("reset upload_cycle to 60 if defined less than 60", func() {
+				fiftyNine := int64(59)
+				instCopy.Spec.Upload.UploadCycle = &fiftyNine
+				createObject(ctx, instCopy)
+
+				fetched := &metricscfgv1beta1.MetricsConfig{}
+
+				Eventually(func() bool {
+					_ = k8sClient.Get(ctx, types.NamespacedName{Name: instCopy.Name, Namespace: namespace}, fetched)
+					return fetched.Status.ClusterID != ""
+				}, timeout, interval).Should(BeTrue())
+
+				Expect(fetched.Status.Upload.UploadCycle).To(Equal(&sixtyInt64))
+			})
 			It("should find service account auth creds for good service account auth CRD case", func() {
 				// Create a valid service account secret
 				instCopy.Spec.APIURL = validTS.URL


### PR DESCRIPTION
Ideally, we would update [this validation](https://github.com/project-koku/koku-metrics-operator/blob/main/api/v1beta1/metricsconfig_types.go#L153) value to prevent the creation of a CR with an upload_cycle less than 60, however, already existing CRs will prevent the operator from upgrading if that value is less than 60. This PR will update the spec to set the value to 60 if it is less than 60. In a future release, we can update the validation to enforce the correct min value.