### PR TITLE
fix the name of the csv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,6 +366,7 @@ downstream: operator-sdk ## Generate the code changes necessary for the downstre
 	$(YQ) -i '.metadata.annotations.support = "Red Hat"' bundle/manifests/costmanagement-metrics-operator.clusterserviceversion.yaml
 	$(YQ) -i '.metadata.annotations."operators.openshift.io/valid-subscription" = "[\"OpenShift Kubernetes Engine\", \"OpenShift Container Platform\", \"OpenShift Platform Plus\"]"' bundle/manifests/costmanagement-metrics-operator.clusterserviceversion.yaml
 	$(YQ) -i '.metadata.annotations.containerImage = "$(DOWNSTREAM_IMAGE_TAG)"' bundle/manifests/costmanagement-metrics-operator.clusterserviceversion.yaml
+	$(YQ) -i '.metadata.name = "costmanagement-metrics-operator.$(VERSION)"' bundle/manifests/costmanagement-metrics-operator.clusterserviceversion.yaml
 	$(YQ) -i '.spec.install.spec.deployments.[0].spec.template.spec.containers.[0].command = ["/usr/bin/costmanagement-metrics-operator"]' bundle/manifests/costmanagement-metrics-operator.clusterserviceversion.yaml
 	$(YQ) -i '.spec.description |= load_str("docs/csv-description.md")' bundle/manifests/costmanagement-metrics-operator.clusterserviceversion.yaml
 	$(YQ) -i '.spec.displayName = "Cost Management Metrics Operator"' bundle/manifests/costmanagement-metrics-operator.clusterserviceversion.yaml

--- a/costmanagement-metrics-operator/3.2.1/manifests/costmanagement-metrics-operator.clusterserviceversion.yaml
+++ b/costmanagement-metrics-operator/3.2.1/manifests/costmanagement-metrics-operator.clusterserviceversion.yaml
@@ -40,7 +40,7 @@ metadata:
     categories: Monitoring
     certified: "true"
     containerImage: registry-proxy.engineering.redhat.com/rh-osbs/costmanagement-metrics-operator:3.2.1
-    createdAt: "2024-03-18T20:21:01Z"
+    createdAt: "2024-03-19T13:51:37Z"
     description: A Golang-based OpenShift Operator that generates and uploads OpenShift usage metrics to cost management.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "false"
@@ -62,7 +62,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: costmanagement-metrics-operator.v3.2.1
+  name: costmanagement-metrics-operator.3.2.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}


### PR DESCRIPTION
The downstream version of the operator does not include the `v` in the ClusterServiceVersion, so this PR removes it.