### PR TITLE
update dependabot groups

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -38,3 +38,6 @@ updates:
       testing-framework:
         patterns:
           - "github.com/onsi/*"
+      prometheus:
+        patterns:
+          - "github.com/prometheus/*"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -34,3 +34,7 @@ updates:
       k8s.io-dependencies:
         patterns:
           - "*k8s.io*"
+          - "github.com/operator-framework"
+      testing-framework:
+        patterns:
+          - "github.com/onsi/*"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -34,7 +34,7 @@ updates:
       k8s.io-dependencies:
         patterns:
           - "*k8s.io*"
-          - "github.com/operator-framework"
+          - "github.com/operator-framework/*"
       testing-framework:
         patterns:
           - "github.com/onsi/*"


### PR DESCRIPTION
* create a group for the testing frameworks -> these almost always update concurrently
* add the operator-framework to the k8s group
* create a group for prometheus