### PR TITLE
[COST-5032] switch to kube_persistentvolume_capacity_bytes

### DIFF
--- a/internal/collector/queries.go
+++ b/internal/collector/queries.go
@@ -15,7 +15,7 @@ var (
 		"cost:node_capacity_memory_bytes":    "kube_node_status_capacity{resource='memory'} * on(node) group_left(provider_id) max by (node, provider_id) (kube_node_info)",
 
 		"cost:persistentvolume_pod_info":            "kube_pod_spec_volumes_persistentvolumeclaims_info * on(persistentvolumeclaim, namespace) group_left(volumename) max by(namespace, persistentvolumeclaim, volumename) (kube_persistentvolumeclaim_info{volumename != ''})",
-		"cost:persistentvolumeclaim_capacity_bytes": "kubelet_volume_stats_capacity_bytes * on(persistentvolumeclaim, namespace) group_left(volumename) max by(namespace, persistentvolumeclaim, volumename) (kube_persistentvolumeclaim_info{volumename != ''})",
+		"cost:persistentvolumeclaim_capacity_bytes": "kube_persistentvolume_capacity_bytes{persistentvolume != ''}",
 		"cost:persistentvolumeclaim_request_bytes":  "kube_persistentvolumeclaim_resource_requests_storage_bytes * on(persistentvolumeclaim, namespace) group_left(volumename) max by(namespace, persistentvolumeclaim, volumename) (kube_persistentvolumeclaim_info{volumename != ''})",
 		"cost:persistentvolumeclaim_usage_bytes":    "kubelet_volume_stats_used_bytes * on(persistentvolumeclaim, namespace) group_left(volumename) max by(namespace, persistentvolumeclaim, volumename) (kube_persistentvolumeclaim_info{volumename != ''})",
 		"cost:persistentvolume_labels":              "kube_persistentvolume_labels * on(persistentvolume, namespace) group_left(storageclass, csi_driver, csi_volume_handle) max by(namespace, persistentvolume, storageclass, csi_driver, csi_volume_handle) (kube_persistentvolume_info)",

--- a/internal/collector/queries.go
+++ b/internal/collector/queries.go
@@ -128,7 +128,7 @@ var (
 				Method:          "max",
 				TransformedName: "persistentvolumeclaim-capacity-byte-seconds",
 			},
-			RowKey: []model.LabelName{"volumename"},
+			RowKey: []model.LabelName{"persistentvolume"},
 		},
 		query{
 			Name:        "persistentvolumeclaim-request-bytes",

--- a/internal/collector/test_files/test_data/persistentvolumeclaim-capacity-bytes
+++ b/internal/collector/test_files/test_data/persistentvolumeclaim-capacity-bytes
@@ -10,7 +10,7 @@
 			"persistentvolumeclaim": "hive-metastore-db-data",
 			"prometheus": "openshift-monitoring/k8s",
 			"service": "kubelet",
-			"volumename": "pvc-025604dc-93ff-4801-ac06-316243ccd45a"
+			"persistentvolume": "pvc-025604dc-93ff-4801-ac06-316243ccd45a"
 		},
 		"values": [
 			[


### PR DESCRIPTION
* `kube_persistentvolume_capacity_bytes` contains data for every PV and it's result actually matches the the value defined in the PV definition.