### PR TITLE
Add  feature annotations

### DIFF
--- a/config/manifests/bases/koku-metrics-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/koku-metrics-operator.clusterserviceversion.yaml
@@ -10,6 +10,9 @@ metadata:
     createdAt: "0001-01-01T00:00:00Z"
     description: A Golang-based OpenShift Operator that generates and uploads OpenShift
       usage metrics to cost management.
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "false"
     features.operators.openshift.io/proxy-aware: "true"

--- a/docs/csv-description.md
+++ b/docs/csv-description.md
@@ -21,21 +21,21 @@ The Koku Metrics Operator (`koku-metrics-operator`) collects the metrics require
 
 ## New in v3.3.2:
 * Leader election settings are now configurable via environment variables. These variables can be modified in the operator [Subscription](https://github.com/operator-framework/operator-lifecycle-manager/blob/5a01f50258003e248bd5630df0837fe0bb0f1cb7/doc/design/subscription-config.md). The values should be specified as durations in seconds in the format `<number-of-seconds>s`. The default values for `LEADER_ELECTION_LEASE_DURATION`, `LEADER_ELECTION_RENEW_DEADLINE`, and `LEADER_ELECTION_RETRY_PERIOD` are '60s', '30s', and '5s', respectively.
-  
+
   ```
-      kind: Subscription
-      metadata:
-      ...
-      spec:
-        ...
-        config:
-          env:
-            - name: LEADER_ELECTION_LEASE_DURATION
-              value: "60s"
-            - name: LEADER_ELECTION_RENEW_DEADLINE
-              value: "30s"
-            - name: LEADER_ELECTION_RETRY_PERIOD
-              value: "5s"
+  kind: Subscription
+  metadata:
+  ...
+  spec:
+    ...
+    config:
+      env:
+      - name: LEADER_ELECTION_LEASE_DURATION
+        value: "30s"
+      - name: LEADER_ELECTION_RENEW_DEADLINE
+        value: "10s"
+      - name: LEADER_ELECTION_RETRY_PERIOD
+        value: "5s"
   ```
 
 ## New in v3.3.1:


### PR DESCRIPTION
Add `features.operators.openshift.io` annotations for (cnf, cni, csi) to the cluster service version(csv). [Docs on defining CSVs](https://docs.openshift.com/container-platform/4.14/operators/operator_sdk/osdk-generating-csvs.html#osdk-csv-annotations-infra_osdk-generating-csvs).
