### PR TITLE
Revert "Update pre-commit hook golangci/golangci-lint to v1.64.8"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
 - repo: https://github.com/golangci/golangci-lint
-  rev: v1.64.8
+  rev: v1.61.0
   hooks:
     - id: golangci-lint


### PR DESCRIPTION
Reverts project-koku/koku-metrics-operator#526