### PR TITLE
Remove deprecated infrastructure-features list annotation

### DIFF
--- a/config/manifests/bases/koku-metrics-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/koku-metrics-operator.clusterserviceversion.yaml
@@ -14,7 +14,7 @@ metadata:
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
     features.operators.openshift.io/disconnected: "true"
-    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/fips-compliant: "false"
     features.operators.openshift.io/proxy-aware: "true"
     features.operators.openshift.io/tls-profiles: "false"
     features.operators.openshift.io/token-auth-aws: "false"

--- a/config/manifests/bases/koku-metrics-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/koku-metrics-operator.clusterserviceversion.yaml
@@ -60,7 +60,6 @@ metadata:
         }
       }
     operatorframework.io/suggested-namespace: koku-metrics-operator
-    operators.openshift.io/infrastructure-features: '["disconnected", "proxy-aware"]'
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/project-koku/koku-metrics-operator

--- a/config/manifests/bases/koku-metrics-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/koku-metrics-operator.clusterserviceversion.yaml
@@ -14,7 +14,7 @@ metadata:
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
     features.operators.openshift.io/disconnected: "true"
-    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "true"
     features.operators.openshift.io/tls-profiles: "false"
     features.operators.openshift.io/token-auth-aws: "false"


### PR DESCRIPTION
Ref: [OpenShift infrastructure features annotations](https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/operators/developing-operators#osdk-csv-annotations-infra_osdk-generating-csvs)

## Summary by Sourcery

Remove redundant infrastructure-features list.

Enhancements:
- Remove the deprecated operators.openshift.io/infrastructure-features annotation from the CSV