### PR TITLE
[COST-5805] Update docs with what's new in v4.0.0

### DIFF
--- a/docs/csv-description.md
+++ b/docs/csv-description.md
@@ -19,6 +19,46 @@ The Koku Metrics Operator (`koku-metrics-operator`) collects the metrics require
 * PersistentVolumeClaim (PVC) configuration: The KokuMetricsConfig CR can accept a PVC definition and the operator will create and mount the PVC. If one is not provided, a default PVC will be created.
 * Restricted network installation: this operator can function on a restricted network. In this mode, the operator stores the packaged reports for manual retrieval.
 
+## New in v4.0.0:
+* **Virtual Machine Metrics:** Adds capabilities for collecting metrics and generating reports specifically for running virtual machines within your OpenShift environment.
+* **FIPS 140 Compliance:** The operator is now enabled for FIPS 140 compliance, meeting stricter security standards.
+* **API Name Change (`KokuMetricsConfig` to `CostManagementMetricsConfig`):** The Custom Resource Definition (CRD) for configuring the upstream `Koku Metrics Operator` has been renamed from `KokuMetricsConfig` to `CostManagementMetricsConfig`.
+
+### NOTE:
+  * The API name change only impacts users of the upstream (community) Koku Metrics Operator.
+  * The downstream (Red Hat-supported) Cost Management Metrics Operator is not impacted by this change and users should continue using their existing configurations.
+
+**Important Upgrade Instructions:**
+
+  If you are upgrading the upstream Koku Metrics Operator to version 4.0.0 or higher, you must manually migrate your configuration. The operator will no longer recognize existing KokuMetricsConfig resources.
+
+  To successfully upgrade and retain your operator's configuration:
+
+  1. Backup Existing Configuration (Optional but Recommended):
+
+     Before upgrading, retrieve the details of your current KokuMetricsConfig instance. This will help you recreate it with the new API name.
+
+     ```
+     oc get kokumetricsconfig -n koku-metrics-operator <your-config-name> -o yaml > koku-metrics-config-backup.yaml
+     ```
+  2. Delete the Old KokuMetricsConfig Instance:
+
+      Once the operator has been upgraded to v4.0.0, you must delete any existing KokuMetricsConfig resources.
+
+      ```
+      oc delete kokumetricsconfig -n koku-metrics-operator <your-config-name>
+      ```
+
+  3. Create the New CostManagementMetricsConfig Instance:
+
+      Using the information from your backup (or a new configuration), create a new CostManagementMetricsConfig instance. Adjust the spec section based on your specific needs. [Refer to the configurable parameters](#configurable-parameters).
+
+  4. Apply your new configuration:
+
+      ```
+      oc apply -f <your-costmanagementmetricsconfig-file>.yaml -n koku-metrics-operator
+      ```
+
 ## New in v3.3.2:
 * Leader election settings are now configurable via environment variables. These variables can be modified in the operator [Subscription](https://github.com/operator-framework/operator-lifecycle-manager/blob/5a01f50258003e248bd5630df0837fe0bb0f1cb7/doc/design/subscription-config.md). The values should be specified as durations in seconds in the format `<number-of-seconds>s`. The default values for `LEADER_ELECTION_LEASE_DURATION`, `LEADER_ELECTION_RENEW_DEADLINE`, and `LEADER_ELECTION_RETRY_PERIOD` are '60s', '30s', and '5s', respectively.
 

--- a/docs/csv-description.md
+++ b/docs/csv-description.md
@@ -20,38 +20,39 @@ The Koku Metrics Operator (`koku-metrics-operator`) collects the metrics require
 * Restricted network installation: this operator can function on a restricted network. In this mode, the operator stores the packaged reports for manual retrieval.
 
 ## New in v4.0.0:
-* **Virtual Machine Metrics:** Adds capabilities for collecting metrics and generating reports specifically for running virtual machines within your OpenShift environment.
-* **Progress towards FIPS 140 Compliance:** The operator is now enabled for its journey towards FIPS 140 compliance through the use of the Go Cryptographic Module v1.0.0. It is important to note that the validation of this module was not finalized at the time of the release. This initiative targets adherence to stricter security standards once the module's FIPS validation is successfully archieved.
-* **API Name Change (`KokuMetricsConfig` to `CostManagementMetricsConfig`):** The Custom Resource Definition (CRD) for configuring the upstream `Koku Metrics Operator` has been renamed from `KokuMetricsConfig` to `CostManagementMetricsConfig`.
+* **Virtual Machine Metrics:** Adds capabilities for collecting metrics and generating reports for running virtual machines within your OpenShift environment.
+* **Progress towards FIPS 140 Compliance:** The operator is using the Go Cryptographic Module v1.0.0 to progress toward FIPS 140 compliance. Although this module is not validated at the time of this release, the operator aims to meet stricter security standards when the module does successfully achieve FIPS validation.
+* **API Name Change:** The Custom Resource Definition (CRD) for configuring the upstream `Koku Metrics Operator` was renamed from `KokuMetricsConfig` to `CostManagementMetricsConfig`.
 
 ### NOTE:
-  * The API name change only impacts users of the upstream (community) Koku Metrics Operator.
+  * The API name change impacts only users of the upstream (community) Koku Metrics Operator.
   * The downstream (Red Hat-supported) Cost Management Metrics Operator is not impacted by this change and users should continue using their existing configurations.
 
 **Important Upgrade Instructions:**
 
-  If you are upgrading the upstream Koku Metrics Operator to version 4.0.0 or higher, you must manually migrate your configuration. The operator will no longer recognize existing KokuMetricsConfig resources.
+  If you are upgrading the upstream Koku Metrics Operator to version 4.0.0 or higher, you must manually migrate your configuration. The operator will no longer recognize existing `KokuMetricsConfig` resources.
 
-  To successfully upgrade and retain your operator's configuration:
+  To successfully upgrade and retain your operator's configuration, complete the following steps. You can use the provided `oc` commands replacing the angle brackets with respective values:
 
-  1. Backup Existing Configuration (Optional but Recommended):
+  1. Backup existing configuration (recommended):
 
-     Before upgrading, retrieve the details of your current KokuMetricsConfig instance. This will help you recreate it with the new API name.
+     Before you upgrade, retrieve the details of your current `KokuMetricsConfig` instance to help you recreate it with the new API name.
 
      ```
      oc get kokumetricsconfig -n koku-metrics-operator <your-config-name> -o yaml > koku-metrics-config-backup.yaml
      ```
-  2. Delete the Old KokuMetricsConfig Instance (Optional but Recommended):
 
-      Once the operator has been upgraded to `version 4.0.0`, delete any existing KokuMetricsConfig resources.
+  2. Delete the previous `KokuMetricsConfig` instance (recommended):
+
+      After the operator is upgraded to `version 4.0.0`, delete any existing `KokuMetricsConfig` resources.
 
       ```
       oc delete kokumetricsconfig -n koku-metrics-operator <your-config-name>
       ```
 
-  3. Create the New CostManagementMetricsConfig Instance:
+  3. Create the new `CostManagementMetricsConfig` instance:
 
-      Using the information from your backup (or a new configuration), create a new CostManagementMetricsConfig instance. Adjust the spec section based on your specific needs. [Refer to the configurable parameters](#configurable-parameters).
+      Using the information from your backup (or a new configuration), create a new `CostManagementMetricsConfig` instance. Adjust the spec section based on your specific needs. For more information about configurations, [refer to the configurable parameters](#configurable-parameters).
 
   4. Apply your new configuration:
 

--- a/docs/csv-description.md
+++ b/docs/csv-description.md
@@ -32,7 +32,7 @@ The Koku Metrics Operator (`koku-metrics-operator`) collects the metrics require
 
   If you are upgrading the upstream Koku Metrics Operator to version 4.0.0 or higher, you must manually migrate your configuration. The operator will no longer recognize existing `KokuMetricsConfig` resources.
 
-  To successfully upgrade and retain your operator's configuration, complete the following steps. You can use the provided `oc` commands replacing the angle brackets with respective values:
+  To successfully upgrade and retain your operator's configuration, complete the following steps. You can use the provided `oc` commands replacing the angle brackets (`< >`) with your specific values:
 
   1. Backup existing configuration (recommended):
 

--- a/docs/csv-description.md
+++ b/docs/csv-description.md
@@ -21,7 +21,7 @@ The Koku Metrics Operator (`koku-metrics-operator`) collects the metrics require
 
 ## New in v4.0.0:
 * **Virtual Machine Metrics:** Adds capabilities for collecting metrics and generating reports specifically for running virtual machines within your OpenShift environment.
-* **FIPS 140 Compliance:** The operator is now enabled for FIPS 140 compliance, meeting stricter security standards.
+* **Progress towards FIPS 140 Compliance:** The operator is now enabled for its journey towards FIPS 140 compliance through the use of the Go Cryptographic Module v1.0.0. It is important to note that the validation of this module was not finalized at the time of the release. This initiative targets adherence to stricter security standards once the module's FIPS validation is successfully archieved.
 * **API Name Change (`KokuMetricsConfig` to `CostManagementMetricsConfig`):** The Custom Resource Definition (CRD) for configuring the upstream `Koku Metrics Operator` has been renamed from `KokuMetricsConfig` to `CostManagementMetricsConfig`.
 
 ### NOTE:
@@ -41,9 +41,9 @@ The Koku Metrics Operator (`koku-metrics-operator`) collects the metrics require
      ```
      oc get kokumetricsconfig -n koku-metrics-operator <your-config-name> -o yaml > koku-metrics-config-backup.yaml
      ```
-  2. Delete the Old KokuMetricsConfig Instance:
+  2. Delete the Old KokuMetricsConfig Instance (Optional but Recommended):
 
-      Once the operator has been upgraded to v4.0.0, you must delete any existing KokuMetricsConfig resources.
+      Once the operator has been upgraded to `version 4.0.0`, delete any existing KokuMetricsConfig resources.
 
       ```
       oc delete kokumetricsconfig -n koku-metrics-operator <your-config-name>

--- a/docs/report-fields-description.md
+++ b/docs/report-fields-description.md
@@ -137,7 +137,7 @@ Fields for metrics related to running virtual machines and their associated reso
 * `vm_os`: The operating system reported by the VM's info.
 * `vm_guest_os_arch`: The guest operating system architecture reported by the VM (e.g., `x86_64`).
 * `vm_guest_os_name`: The guest operating system name reported by the VM (e.g., `RHEL`, `Fedora`).
-* `vm_guest_os_version_id`: The guest operating system version ID reported by the VM (e.g., `8.6`).
+* `vm_guest_os_version`: The guest operating system version ID reported by the VM (e.g., `8.6`).
 * `vm_uptime_total_seconds`: The total uptime of the VMI in seconds since it started.
 * `vm_cpu_limit_cores`: CPU core limit configured, representing the maximum number of cores the VM can use.
 * `vm_cpu_limit_core_seconds`: Total CPU core seconds limited for the VM over the reporting period.

--- a/docs/report-fields-description.md
+++ b/docs/report-fields-description.md
@@ -31,7 +31,7 @@ These common fields are included in all the reports and provide temporal informa
 Fields for metrics related to containers:
 
 * `container_name`: The name of the container.
-* `pod`: The name of the pod that contains the container.
+* `pod`: The name of the pod that associated with the container.
 * `owner_name`: The name of the owner entity that is associated with the container. For example Deployment or StatefulSet.
 * `owner_kind`: The kind of the owner entity that is associated with the container. For example Deployment or StatefulSet.
 * `workload`: The workload associated with the container.
@@ -129,7 +129,7 @@ Fields for metrics related to namespaces:
 
 Fields for metrics related to running virtual machines (VMs) and their associated resources:
 
-* `node`: The name of the node where the VM instance (VMI) is currently running.
+* `node`: The name of the node where the virtual machine instance (VMI) is currently running.
 * `namespace`: The namespace where the virtual machine (VM) is defined.
 * `resource_id`: The unique identifier of the VM on the node. This is derived from the `provider_id` of the node, specifically the segment after the last `/` character. For example, if the `provider_id` is `aws:///us-east-1a/i-0abcdef1234567890`, the `resource_id` is `i-0abcdef1234567890`.
 * `vm_name`: The name of the VM.

--- a/docs/report-fields-description.md
+++ b/docs/report-fields-description.md
@@ -1,15 +1,15 @@
 # Report Fields For Collected Metrics
 
-This document provides an outline of the fields included in the collected usage metrics. These metrics relate to containers, persistent volumes, nodes, pods, and namespaces. 
+This document provides an outline of the fields included in the collected usage metrics. These metrics relate to containers, persistent volumes, nodes, pods, and namespaces.
 
 
 **NOTE:**
 
-- The [Prometheus queries](https://github.com/project-koku/koku-metrics-operator/blob/main/internal/collector/queries.go) used by the operator to collect metrics are detailed in the linked file. 
+* The [Prometheus queries](https://github.com/project-koku/koku-metrics-operator/blob/main/internal/collector/queries.go) used by the operator to collect metrics are detailed in the linked file.
 
-- To enable the collection ROS (Resource Optimization) metrics, ensure that the namespace(s) are labeled with `insights_cost_management_optimizations='true'`.
+* To enable the collection ROS (Resource Optimization) metrics, ensure that the namespace(s) are labeled with `insights_cost_management_optimizations='true'`.
 
-    - Queries responsible for collecting ROS metrics are identified in the `QueryMap` with the prefix `ros:` and include a specific filter to target the appropriately labeled namespaces:
+    * Queries responsible for collecting ROS metrics are identified in the `QueryMap` with the prefix `ros:` and include a specific filter to target the appropriately labeled namespaces:
         ```
         kube_namespace_labels{label_insights_cost_management_optimizations='true', namespace!~'kube-.*|openshift|openshift-.*'}
         ```
@@ -17,99 +17,146 @@ This document provides an outline of the fields included in the collected usage 
 
 ### 1. Common Fields
 
-- `report_period_start`: The start timestamp of the reporting period.
-- `report_period_end`: The end timestamp of the reporting period.
-- `interval_start`: The start timestamp of the reporting interval.
-- `interval_end`: The end timestamp of the reporting interval.
+* `report_period_start`: The start timestamp of the reporting period.
+* `report_period_end`: The end timestamp of the reporting period.
+* `interval_start`: The start timestamp of the reporting interval.
+* `interval_end`: The end timestamp of the reporting interval.
 
 These common fields are included in all the reports and provide temporal information about the reporting period and interval.
+
+---
 
 ### 2. Container Metrics
 
 Fields for metrics related to containers:
 
+* `container_name`: The name of the container.
+* `pod`: The name of the pod that contains the container.
+* `owner_name`: The name of the owner entity (e.g., Deployment, StatefulSet) associated with the container.
+* `owner_kind`: The kind of the owner entity (e.g., Deployment, StatefulSet) associated with the container.
+* `workload`: The workload associated with the container.
+* `workload_type`: The type of the workload (e.g., Deployment, StatefulSet).
+* `namespace`: The namespace of the container.
+* `image_name`: The name of the container's image.
+* `node`: The node on which the container is running.
+* `resource_id`: The ID of the resource.
+* `cpu_request_container_avg`: Average CPU request for the container.
+* `cpu_request_container_sum`: Total CPU request for the container.
+* `cpu_limit_container_avg`: Average CPU limit for the container.
+* `cpu_limit_container_sum`: Total CPU limit for the container.
+* `cpu_usage_container_avg`: Average CPU usage for the container.
+* `cpu_usage_container_min`: Minimum CPU usage for the container.
+* `cpu_usage_container_max`: Maximum CPU usage for the container.
+* `cpu_usage_container_sum`: Total CPU usage for the container.
+* `cpu_throttle_container_avg`: Average CPU throttle for the container.
+* `cpu_throttle_container_max`: Maximum CPU throttle for the container.
+* `cpu_throttle_container_sum`: Total CPU throttle for the container.
+* `memory_request_container_avg`: Average memory request for the container.
+* `memory_request_container_sum`: Total memory request for the container.
+* `memory_limit_container_avg`: Average memory limit for the container.
+* `memory_limit_container_sum`: Total memory limit for the container.
+* `memory_usage_container_avg`: Average memory usage for the container.
+* `memory_usage_container_min`: Minimum memory usage for the container.
+* `memory_usage_container_max`: Maximum memory usage for the container.
+* `memory_usage_container_sum`: Total memory usage for the container.
+* `memory_rss_usage_container_avg`: Average RSS memory usage for the container.
+* `memory_rss_usage_container_min`: Minimum RSS memory usage for the container.
+* `memory_rss_usage_container_max`: Maximum RSS memory usage for the container.
+* `memory_rss_usage_container_sum`: Total RSS memory usage for the container.
 
-- `container_name`: The name of the container.
-- `pod`: The name of the pod that contains the container.
-- `owner_name`: The name of the owner entity (e.g., Deployment, StatefulSet) associated with the container.
-- `owner_kind`: The kind of the owner entity (e.g., Deployment, StatefulSet) associated with the container.
-- `workload`: The workload associated with the container.
-- `workload_type`: The type of the workload (e.g., Deployment, StatefulSet).
-- `namespace`: The namespace of the container.
-- `image_name`: The name of the container's image.
-- `node`: The node on which the container is running.
-- `resource_id`: The ID of the resource.
-- `cpu_request_container_avg`: Average CPU request for the container.
-- `cpu_request_container_sum`: Total CPU request for the container.
-- `cpu_limit_container_avg`: Average CPU limit for the container.
-- `cpu_limit_container_sum`: Total CPU limit for the container.
-- `cpu_usage_container_avg`: Average CPU usage for the container.
-- `cpu_usage_container_min`: Minimum CPU usage for the container.
-- `cpu_usage_container_max`: Maximum CPU usage for the container.
-- `cpu_usage_container_sum`: Total CPU usage for the container.
-- `cpu_throttle_container_avg`: Average CPU throttle for the container.
-- `cpu_throttle_container_max`: Maximum CPU throttle for the container.
-- `cpu_throttle_container_sum`: Total CPU throttle for the container.
-- `memory_request_container_avg`: Average memory request for the container.
-- `memory_request_container_sum`: Total memory request for the container.
-- `memory_limit_container_avg`: Average memory limit for the container.
-- `memory_limit_container_sum`: Total memory limit for the container.
-- `memory_usage_container_avg`: Average memory usage for the container.
-- `memory_usage_container_min`: Minimum memory usage for the container.
-- `memory_usage_container_max`: Maximum memory usage for the container.
-- `memory_usage_container_sum`: Total memory usage for the container.
-- `memory_rss_usage_container_avg`: Average RSS memory usage for the container.
-- `memory_rss_usage_container_min`: Minimum RSS memory usage for the container.
-- `memory_rss_usage_container_max`: Maximum RSS memory usage for the container.
-- `memory_rss_usage_container_sum`: Total RSS memory usage for the container.
+---
 
 ### 3. Persistent Volume Metrics
 
 Fields for metrics related to persistent volumes:
 
-- `namespace`: The namespace associated with the persistent volume claim.
-- `pod`: The name of the pod associated with the persistent volume claim.
-- `persistentvolumeclaim`: The name of the persistent volume claim.
-- `persistentvolume`: The name of the persistent volume.
-- `storageclass`: The storage class of the persistent volume claim.
-- `persistentvolumeclaim_capacity_bytes`: Capacity of the persistent volume claim in bytes.
-- `persistentvolumeclaim_capacity_byte_seconds`: Capacity of the persistent volume claim in byte seconds.
-- `volume_request_storage_byte_seconds`: Storage byte seconds requested by the volume.
-- `persistentvolumeclaim_usage_byte_seconds`: Usage byte seconds of the persistent volume claim.
-- `persistentvolume_labels`: Labels associated with the persistent volume.
-- `persistentvolumeclaim_labels`: Labels associated with the persistent volume claim.
+* `namespace`: The namespace associated with the persistent volume claim.
+* `pod`: The name of the pod associated with the persistent volume claim.
+* `persistentvolumeclaim`: The name of the persistent volume claim.
+* `persistentvolume`: The name of the persistent volume.
+* `storageclass`: The storage class of the persistent volume claim.
+* `persistentvolumeclaim_capacity_bytes`: Capacity of the persistent volume claim in bytes.
+* `persistentvolumeclaim_capacity_byte_seconds`: Capacity of the persistent volume claim in byte seconds.
+* `volume_request_storage_byte_seconds`: Storage byte seconds requested by the volume.
+* `persistentvolumeclaim_usage_byte_seconds`: Usage byte seconds of the persistent volume claim.
+* `persistentvolume_labels`: Labels associated with the persistent volume.
+* `persistentvolumeclaim_labels`: Labels associated with the persistent volume claim.
+
+---
 
 ### 4. Node Metrics
 
 Fields for metrics related to nodes:
 
-- `node`: The name of the node.
-- `node_labels`: Labels associated with the node.
+* `node`: The name of the node.
+* `node_labels`: Labels associated with the node.
+
+---
 
 ### 5. Pod Metrics
 
 Fields for metrics related to pods:
 
-- `node`: The name of the node.
-- `namespace`: The namespace of the pod.
-- `pod`: The name of the pod.
-- `pod_usage_cpu_core_seconds`: CPU core seconds used by the pod.
-- `pod_request_cpu_core_seconds`: CPU core seconds requested by the pod.
-- `pod_limit_cpu_core_seconds`: CPU core seconds limited for the pod.
-- `pod_usage_memory_byte_seconds`: Memory byte seconds used by the pod.
-- `pod_request_memory_byte_seconds`: Memory byte seconds requested by the pod.
-- `pod_limit_memory_byte_seconds`: Memory byte seconds limited for the pod.
-- `node_capacity_cpu_cores`: CPU cores capacity of the node.
-- `node_capacity_cpu_core_seconds`: CPU core seconds capacity of the node.
-- `node_capacity_memory_bytes`: Memory bytes capacity of the node.
-- `node_capacity_memory_byte_seconds`: Memory byte seconds capacity of the node.
-- `node_role`: The role of the node.
-- `resource_id`: The ID of the resource.
-- `pod_labels`: Labels associated with the pod.
+* `node`: The name of the node.
+* `namespace`: The namespace of the pod.
+* `pod`: The name of the pod.
+* `pod_usage_cpu_core_seconds`: CPU core seconds used by the pod.
+* `pod_request_cpu_core_seconds`: CPU core seconds requested by the pod.
+* `pod_limit_cpu_core_seconds`: CPU core seconds limited for the pod.
+* `pod_usage_memory_byte_seconds`: Memory byte seconds used by the pod.
+* `pod_request_memory_byte_seconds`: Memory byte seconds requested by the pod.
+* `pod_limit_memory_byte_seconds`: Memory byte seconds limited for the pod.
+* `node_capacity_cpu_cores`: CPU cores capacity of the node.
+* `node_capacity_cpu_core_seconds`: CPU core seconds capacity of the node.
+* `node_capacity_memory_bytes`: Memory bytes capacity of the node.
+* `node_capacity_memory_byte_seconds`: Memory byte seconds capacity of the node.
+* `node_role`: The role of the node.
+* `resource_id`: The ID of the resource.
+* `pod_labels`: Labels associated with the pod.
+
+---
 
 ### 6. Namespace Metrics Report
 
 Fields for metrics related to namespaces:
 
-- `namespace`: The namespace.
-- `namespace_labels`: Labels associated with the namespace.
+* `namespace`: The namespace.
+* `namespace_labels`: Labels associated with the namespace.
+
+---
+
+### 7. VM Metrics
+
+Fields for metrics related to running virtual machines and their associated resources:
+
+* `node`: The name of the node where the VM instance (VMI) is currently running.
+* `namespace`: The namespace where the VM (VM) is defined.
+* `resource_id`: The unique identifier of the VM on the node. This is derived from the `provider_id` of the node, specifically the segment after the last `/` character (e.g., if `provider_id` is `aws:///us-east-1a/i-0abcdef1234567890`, `resource_id` would be `i-0abcdef1234567890`).
+* `vm_name`: The name of the VM.
+* `vm_instance_type`: The instance type associated with the VM, if defined.
+* `vm_os`: The operating system reported by the VM's info.
+* `vm_guest_os_arch`: The guest operating system architecture reported by the VM (e.g., `x86_64`).
+* `vm_guest_os_name`: The guest operating system name reported by the VM (e.g., `RHEL`, `Fedora`).
+* `vm_guest_os_version_id`: The guest operating system version ID reported by the VM (e.g., `8.6`).
+* `vm_uptime_total_seconds`: The total uptime of the VMI in seconds since it started.
+* `vm_cpu_limit_cores`: CPU core limit configured, representing the maximum number of cores the VM can use.
+* `vm_cpu_limit_core_seconds`: Total CPU core seconds limited for the VM over the reporting period.
+* `vm_cpu_request_cores`: CPU core request configured for the VM, representing the guaranteed number of cores the VM will receive.
+* `vm_cpu_request_core_seconds`: Total CPU core seconds requested for the VM over the reporting period.
+* `vm_cpu_request_sockets`: Number of CPU sockets requested for the VM.
+* `vm_cpu_request_socket_seconds`: Total CPU socket seconds requested for the VM over the reporting period.
+* `vm_cpu_request_threads`: Number of CPU threads requested per core for the VM.
+* `vm_cpu_request_thread_seconds`: Total CPU thread seconds requested for the VM over the reporting period.
+* `vm_cpu_usage_total_seconds`: Total CPU usage of the VM in seconds over the reporting period.
+* `vm_memory_limit_bytes`: Memory limit configured for the VM in bytes, representing the maximum memory the VM can use.
+* `vm_memory_limit_byte_seconds`: Total memory byte seconds limited for the VM over the reporting period.
+* `vm_memory_request_bytes`: Memory request configured for the VM in bytes, representing the guaranteed memory the VM will receive.
+* `vm_memory_request_byte_seconds`: Total memory byte seconds requested for the VM over the reporting period.
+* `vm_memory_usage_byte_seconds`: Total memory usage of the VM in byte seconds over the reporting period.
+* `vm_device`: Name of the virtual device attached to the VM, typically referring to a disk.
+* `vm_volume_mode`: The volume mode of the attached disk (e.g., `Block`, `Filesystem`).
+* `vm_persistentvolumeclaim_name`: Name of the PersistentVolumeClaim backing the VM's disk.
+* `vm_disk_allocated_size_byte_seconds`: Total allocated disk size for the VM's storage in byte seconds over the reporting period.
+* `vm_labels`: A JSON string representing key-value pairs of labels applied to the VM.
+
+---

--- a/docs/report-fields-description.md
+++ b/docs/report-fields-description.md
@@ -7,7 +7,7 @@ This document provides an outline of the fields included in the collected usage 
 
 * The [Prometheus queries](https://github.com/project-koku/koku-metrics-operator/blob/main/internal/collector/queries.go) that the operator uses to collect metrics are detailed in the linked file.
 
-* To enable the collection ROS (Resource Optimization) metrics, ensure that the namespace(s) are labeled with `insights_cost_management_optimizations='true'`.
+* To enable the collection ROS (Resource Optimization) metrics, ensure that the namespaces are labeled with `insights_cost_management_optimizations='true'`.
 
     * Queries responsible for collecting ROS metrics are identified in the `QueryMap` with the prefix `ros:` and include a specific filter to target the appropriately labeled namespaces:
         ```

--- a/docs/report-fields-description.md
+++ b/docs/report-fields-description.md
@@ -5,7 +5,7 @@ This document provides an outline of the fields included in the collected usage 
 
 **NOTE:**
 
-* The [Prometheus queries](https://github.com/project-koku/koku-metrics-operator/blob/main/internal/collector/queries.go) used by the operator to collect metrics are detailed in the linked file.
+* The [Prometheus queries](https://github.com/project-koku/koku-metrics-operator/blob/main/internal/collector/queries.go) that the operator uses to collect metrics are detailed in the linked file.
 
 * To enable the collection ROS (Resource Optimization) metrics, ensure that the namespace(s) are labeled with `insights_cost_management_optimizations='true'`.
 
@@ -32,55 +32,55 @@ Fields for metrics related to containers:
 
 * `container_name`: The name of the container.
 * `pod`: The name of the pod that contains the container.
-* `owner_name`: The name of the owner entity (e.g., Deployment, StatefulSet) associated with the container.
-* `owner_kind`: The kind of the owner entity (e.g., Deployment, StatefulSet) associated with the container.
+* `owner_name`: The name of the owner entity that is associated with the container. For example Deployment or StatefulSet.
+* `owner_kind`: The kind of the owner entity that is associated with the container. For example Deployment or StatefulSet.
 * `workload`: The workload associated with the container.
-* `workload_type`: The type of the workload (e.g., Deployment, StatefulSet).
+* `workload_type`: The type of the workload.
 * `namespace`: The namespace of the container.
 * `image_name`: The name of the container's image.
 * `node`: The node on which the container is running.
-* `resource_id`: The ID of the resource.
-* `cpu_request_container_avg`: Average CPU request for the container.
-* `cpu_request_container_sum`: Total CPU request for the container.
-* `cpu_limit_container_avg`: Average CPU limit for the container.
-* `cpu_limit_container_sum`: Total CPU limit for the container.
-* `cpu_usage_container_avg`: Average CPU usage for the container.
-* `cpu_usage_container_min`: Minimum CPU usage for the container.
-* `cpu_usage_container_max`: Maximum CPU usage for the container.
-* `cpu_usage_container_sum`: Total CPU usage for the container.
-* `cpu_throttle_container_avg`: Average CPU throttle for the container.
-* `cpu_throttle_container_max`: Maximum CPU throttle for the container.
-* `cpu_throttle_container_sum`: Total CPU throttle for the container.
-* `memory_request_container_avg`: Average memory request for the container.
-* `memory_request_container_sum`: Total memory request for the container.
-* `memory_limit_container_avg`: Average memory limit for the container.
-* `memory_limit_container_sum`: Total memory limit for the container.
-* `memory_usage_container_avg`: Average memory usage for the container.
-* `memory_usage_container_min`: Minimum memory usage for the container.
-* `memory_usage_container_max`: Maximum memory usage for the container.
-* `memory_usage_container_sum`: Total memory usage for the container.
-* `memory_rss_usage_container_avg`: Average RSS memory usage for the container.
-* `memory_rss_usage_container_min`: Minimum RSS memory usage for the container.
-* `memory_rss_usage_container_max`: Maximum RSS memory usage for the container.
-* `memory_rss_usage_container_sum`: Total RSS memory usage for the container.
+* `resource_id`: The unique identifier of the resource.
+* `cpu_request_container_avg`: The average CPU request for the container.
+* `cpu_request_container_sum`: The total CPU request for the container.
+* `cpu_limit_container_avg`: The average CPU limit for the container.
+* `cpu_limit_container_sum`: The total CPU limit for the container.
+* `cpu_usage_container_avg`: The average CPU usage for the container.
+* `cpu_usage_container_min`: The minimum CPU usage for the container.
+* `cpu_usage_container_max`: The maximum CPU usage for the container.
+* `cpu_usage_container_sum`: The total CPU usage for the container.
+* `cpu_throttle_container_avg`: The average CPU throttle for the container.
+* `cpu_throttle_container_max`: The maximum CPU throttle for the container.
+* `cpu_throttle_container_sum`: The total CPU throttle for the container.
+* `memory_request_container_avg`: The average memory request for the container.
+* `memory_request_container_sum`: The total memory request for the container.
+* `memory_limit_container_avg`: The average memory limit for the container.
+* `memory_limit_container_sum`: The total memory limit for the container.
+* `memory_usage_container_avg`: The average memory usage for the container.
+* `memory_usage_container_min`: The minimum memory usage for the container.
+* `memory_usage_container_max`: The maximum memory usage for the container.
+* `memory_usage_container_sum`: The total memory usage for the container.
+* `memory_rss_usage_container_avg`: The average RSS memory usage for the container.
+* `memory_rss_usage_container_min`: The minimum RSS memory usage for the container.
+* `memory_rss_usage_container_max`: The maximum RSS memory usage for the container.
+* `memory_rss_usage_container_sum`: The total RSS memory usage for the container.
 
 ---
 
 ### 3. Persistent Volume Metrics
 
-Fields for metrics related to persistent volumes:
+Fields for metrics related to Persistent Volumes (PVs):
 
-* `namespace`: The namespace associated with the persistent volume claim.
+* `namespace`: The namespace associated with the persistent volume claim (PVC).
 * `pod`: The name of the pod associated with the persistent volume claim.
 * `persistentvolumeclaim`: The name of the persistent volume claim.
 * `persistentvolume`: The name of the persistent volume.
 * `storageclass`: The storage class of the persistent volume claim.
-* `persistentvolumeclaim_capacity_bytes`: Capacity of the persistent volume claim in bytes.
-* `persistentvolumeclaim_capacity_byte_seconds`: Capacity of the persistent volume claim in byte seconds.
-* `volume_request_storage_byte_seconds`: Storage byte seconds requested by the volume.
-* `persistentvolumeclaim_usage_byte_seconds`: Usage byte seconds of the persistent volume claim.
-* `persistentvolume_labels`: Labels associated with the persistent volume.
-* `persistentvolumeclaim_labels`: Labels associated with the persistent volume claim.
+* `persistentvolumeclaim_capacity_bytes`: The capacity of the persistent volume claim in bytes.
+* `persistentvolumeclaim_capacity_byte_seconds`: The capacity of the persistent volume claim in byte seconds.
+* `volume_request_storage_byte_seconds`: The storage byte seconds requested by the volume.
+* `persistentvolumeclaim_usage_byte_seconds`: The usage byte seconds of the persistent volume claim.
+* `persistentvolume_labels`: The labels associated with the persistent volume.
+* `persistentvolumeclaim_labels`: The labels associated with the persistent volume claim.
 
 ---
 
@@ -89,7 +89,7 @@ Fields for metrics related to persistent volumes:
 Fields for metrics related to nodes:
 
 * `node`: The name of the node.
-* `node_labels`: Labels associated with the node.
+* `node_labels`: The labels associated with the node.
 
 ---
 
@@ -100,19 +100,19 @@ Fields for metrics related to pods:
 * `node`: The name of the node.
 * `namespace`: The namespace of the pod.
 * `pod`: The name of the pod.
-* `pod_usage_cpu_core_seconds`: CPU core seconds used by the pod.
-* `pod_request_cpu_core_seconds`: CPU core seconds requested by the pod.
-* `pod_limit_cpu_core_seconds`: CPU core seconds limited for the pod.
-* `pod_usage_memory_byte_seconds`: Memory byte seconds used by the pod.
-* `pod_request_memory_byte_seconds`: Memory byte seconds requested by the pod.
-* `pod_limit_memory_byte_seconds`: Memory byte seconds limited for the pod.
-* `node_capacity_cpu_cores`: CPU cores capacity of the node.
-* `node_capacity_cpu_core_seconds`: CPU core seconds capacity of the node.
-* `node_capacity_memory_bytes`: Memory bytes capacity of the node.
-* `node_capacity_memory_byte_seconds`: Memory byte seconds capacity of the node.
+* `pod_usage_cpu_core_seconds`: The CPU core seconds used by the pod.
+* `pod_request_cpu_core_seconds`: The CPU core seconds requested by the pod.
+* `pod_limit_cpu_core_seconds`: The CPU core seconds limited for the pod.
+* `pod_usage_memory_byte_seconds`: The memory byte seconds used by the pod.
+* `pod_request_memory_byte_seconds`: The memory byte seconds requested by the pod.
+* `pod_limit_memory_byte_seconds`: The memory byte seconds limited for the pod.
+* `node_capacity_cpu_cores`: The CPU cores capacity of the node.
+* `node_capacity_cpu_core_seconds`: The CPU core seconds capacity of the node.
+* `node_capacity_memory_bytes`: The memory bytes capacity of the node.
+* `node_capacity_memory_byte_seconds`: The memory byte seconds capacity of the node.
 * `node_role`: The role of the node.
-* `resource_id`: The ID of the resource.
-* `pod_labels`: Labels associated with the pod.
+* `resource_id`: The unique identifier of the resource.
+* `pod_labels`: The labels associated with the pod.
 
 ---
 
@@ -121,42 +121,42 @@ Fields for metrics related to pods:
 Fields for metrics related to namespaces:
 
 * `namespace`: The namespace.
-* `namespace_labels`: Labels associated with the namespace.
+* `namespace_labels`: The labels associated with the namespace.
 
 ---
 
 ### 7. VM Metrics
 
-Fields for metrics related to running virtual machines and their associated resources:
+Fields for metrics related to running virtual machines (VMs) and their associated resources:
 
 * `node`: The name of the node where the VM instance (VMI) is currently running.
-* `namespace`: The namespace where the VM (VM) is defined.
-* `resource_id`: The unique identifier of the VM on the node. This is derived from the `provider_id` of the node, specifically the segment after the last `/` character (e.g., if `provider_id` is `aws:///us-east-1a/i-0abcdef1234567890`, `resource_id` would be `i-0abcdef1234567890`).
+* `namespace`: The namespace where the virtual machine (VM) is defined.
+* `resource_id`: The unique identifier of the VM on the node. This is derived from the `provider_id` of the node, specifically the segment after the last `/` character. For example, if the `provider_id` is `aws:///us-east-1a/i-0abcdef1234567890`, the `resource_id` is `i-0abcdef1234567890`.
 * `vm_name`: The name of the VM.
 * `vm_instance_type`: The instance type associated with the VM, if defined.
 * `vm_os`: The operating system reported by the VM's info.
-* `vm_guest_os_arch`: The guest operating system architecture reported by the VM (e.g., `x86_64`).
-* `vm_guest_os_name`: The guest operating system name reported by the VM (e.g., `RHEL`, `Fedora`).
-* `vm_guest_os_version`: The guest operating system version ID reported by the VM (e.g., `8.6`).
+* `vm_guest_os_arch`: The guest operating system architecture reported by the VM. For example x86_64.
+* `vm_guest_os_name`: The guest operating system name reported by the VM. For example RHEL or Fedora.
+* `vm_guest_os_version`: The guest operating system version number reported by the VM. For example 8.6.
 * `vm_uptime_total_seconds`: The total uptime of the VMI in seconds since it started.
-* `vm_cpu_limit_cores`: CPU core limit configured, representing the maximum number of cores the VM can use.
-* `vm_cpu_limit_core_seconds`: Total CPU core seconds limited for the VM over the reporting period.
-* `vm_cpu_request_cores`: CPU core request configured for the VM, representing the guaranteed number of cores the VM will receive.
-* `vm_cpu_request_core_seconds`: Total CPU core seconds requested for the VM over the reporting period.
-* `vm_cpu_request_sockets`: Number of CPU sockets requested for the VM.
-* `vm_cpu_request_socket_seconds`: Total CPU socket seconds requested for the VM over the reporting period.
-* `vm_cpu_request_threads`: Number of CPU threads requested per core for the VM.
-* `vm_cpu_request_thread_seconds`: Total CPU thread seconds requested for the VM over the reporting period.
-* `vm_cpu_usage_total_seconds`: Total CPU usage of the VM in seconds over the reporting period.
-* `vm_memory_limit_bytes`: Memory limit configured for the VM in bytes, representing the maximum memory the VM can use.
-* `vm_memory_limit_byte_seconds`: Total memory byte seconds limited for the VM over the reporting period.
-* `vm_memory_request_bytes`: Memory request configured for the VM in bytes, representing the guaranteed memory the VM will receive.
-* `vm_memory_request_byte_seconds`: Total memory byte seconds requested for the VM over the reporting period.
-* `vm_memory_usage_byte_seconds`: Total memory usage of the VM in byte seconds over the reporting period.
-* `vm_device`: Name of the virtual device attached to the VM, typically referring to a disk.
-* `vm_volume_mode`: The volume mode of the attached disk (e.g., `Block`, `Filesystem`).
-* `vm_persistentvolumeclaim_name`: Name of the PersistentVolumeClaim backing the VM's disk.
-* `vm_disk_allocated_size_byte_seconds`: Total allocated disk size for the VM's storage in byte seconds over the reporting period.
+* `vm_cpu_limit_cores`: The CPU core limit configured, representing the maximum number of cores the VM can use.
+* `vm_cpu_limit_core_seconds`: The total CPU core seconds limited for the VM over the reporting period.
+* `vm_cpu_request_cores`: The CPU core request configured for the VM, representing the guaranteed number of cores the VM will receive.
+* `vm_cpu_request_core_seconds`: The total CPU core seconds requested for the VM over the reporting period.
+* `vm_cpu_request_sockets`: The number of CPU sockets requested for the VM.
+* `vm_cpu_request_socket_seconds`: The total CPU socket seconds requested for the VM over the reporting period.
+* `vm_cpu_request_threads`: The number of CPU threads requested per core for the VM.
+* `vm_cpu_request_thread_seconds`: The total CPU thread seconds requested for the VM over the reporting period.
+* `vm_cpu_usage_total_seconds`: The total CPU usage of the VM in seconds over the reporting period.
+* `vm_memory_limit_bytes`: The memory limit configured for the VM in bytes, representing the maximum memory the VM can use.
+* `vm_memory_limit_byte_seconds`: The total memory byte seconds limited for the VM over the reporting period.
+* `vm_memory_request_bytes`: The memory request configured for the VM in bytes, representing the guaranteed memory the VM will receive.
+* `vm_memory_request_byte_seconds`: The total memory byte seconds requested for the VM over the reporting period.
+* `vm_memory_usage_byte_seconds`: The total memory usage of the VM in byte seconds over the reporting period.
+* `vm_device`: The name of the virtual device attached to the VM, typically referring to a disk.
+* `vm_volume_mode`: The volume mode of the attached disk. For example Block or Filesystem.
+* `vm_persistentvolumeclaim_name`: The name of the `PersistentVolumeClaim` backing the VM's disk.
+* `vm_disk_allocated_size_byte_seconds`: The total allocated disk size for the VM's storage in byte seconds over the reporting period.
 * `vm_labels`: A JSON string representing key-value pairs of labels applied to the VM.
 
 ---


### PR DESCRIPTION
## Jira Ticket

[COST-5805](https://issues.redhat.com/browse/COST-5805)

* Update docs with new enhancements in v4.0.0.
* Add upgrade instructions for upstream koku metrics operator.
* Add descriptions for VM report columns.

## Summary by Sourcery

Update documentation to reflect v4.0.0 enhancements, including new VM metrics, FIPS 140 compliance, CRD rename, and upgrade instructions.

Documentation:
- Document new VM metrics fields in report-fields-description.md
- Add v4.0.0 release notes to csv-description.md covering Virtual Machine Metrics, FIPS 140 compliance, and the CRD rename
- Provide explicit upgrade instructions for upstream operator migration from KokuMetricsConfig to CostManagementMetricsConfig
- Standardize Markdown list formatting for consistency across documentation