### PR TITLE
Add serviceAccountName to taskRunTemplate in bundle and operator YAML…

### DIFF
--- a/.tekton/bundle-pr.yaml
+++ b/.tekton/bundle-pr.yaml
@@ -22,6 +22,9 @@ metadata:
   name: downstream-operator-bundle-pr
   namespace: cost-mgmt-dev-tenant
 spec:
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-costmanagement-metrics-operator-bundle
+
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -470,7 +473,6 @@ spec:
       optional: true
     - name: netrc
       optional: true
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/bundle-push.yaml
+++ b/.tekton/bundle-push.yaml
@@ -21,6 +21,9 @@ metadata:
   name: downstream-operator-bundle-push
   namespace: cost-mgmt-dev-tenant
 spec:
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-costmanagement-metrics-operator-bundle
+
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -467,7 +470,6 @@ spec:
       optional: true
     - name: netrc
       optional: true
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/operator-pr.yaml
+++ b/.tekton/operator-pr.yaml
@@ -20,6 +20,9 @@ metadata:
   name: downstream-operator-pr
   namespace: cost-mgmt-dev-tenant
 spec:
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-costmanagement-metrics-operator
+
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -484,7 +487,6 @@ spec:
       optional: true
     - name: netrc
       optional: true
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/operator-push.yaml
+++ b/.tekton/operator-push.yaml
@@ -19,6 +19,9 @@ metadata:
   name: downstream-operator-push
   namespace: cost-mgmt-dev-tenant
 spec:
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-costmanagement-metrics-operator
+
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -481,7 +484,6 @@ spec:
       optional: true
     - name: netrc
       optional: true
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
… files

## Summary by Sourcery

Configure Tekton TaskRun templates to use specific service accounts for both bundle and operator pipelines.

Enhancements:
- Add serviceAccountName to taskRunTemplate in bundle PR and push pipeline YAMLs
- Add serviceAccountName to taskRunTemplate in operator PR and push pipeline YAMLs
- Remove empty taskRunTemplate placeholders from existing pipeline configurations