### PR TITLE
[COST-6095] bundle for koku metrics operator v4.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-PREVIOUS_VERSION ?= 3.3.1
-VERSION ?= 3.3.2
+PREVIOUS_VERSION ?= 3.3.2
+VERSION ?= 4.0.0
 
 MIN_KUBE_VERSION = 1.24.0
 MIN_OCP_VERSION = 4.12

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=koku-metrics-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha,beta
 LABEL operators.operatorframework.io.bundle.channel.default.v1=beta
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.35.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.39.2
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 

--- a/bundle/manifests/costmanagement-metrics-cfg.openshift.io_costmanagementmetricsconfigs.yaml
+++ b/bundle/manifests/costmanagement-metrics-cfg.openshift.io_costmanagementmetricsconfigs.yaml
@@ -2,24 +2,25 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.5
   creationTimestamp: null
   labels:
     app: koku-metrics-operator
-  name: kokumetricsconfigs.koku-metrics-cfg.openshift.io
+  name: costmanagementmetricsconfigs.costmanagement-metrics-cfg.openshift.io
 spec:
-  group: koku-metrics-cfg.openshift.io
+  group: costmanagement-metrics-cfg.openshift.io
   names:
-    kind: KokuMetricsConfig
-    listKind: KokuMetricsConfigList
-    plural: kokumetricsconfigs
-    singular: kokumetricsconfig
+    kind: CostManagementMetricsConfig
+    listKind: CostManagementMetricsConfigList
+    plural: costmanagementmetricsconfigs
+    singular: costmanagementmetricsconfig
   scope: Namespaced
   versions:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: KokuMetricsConfig is the Schema for the kokumetricsconfig API
+        description: CostManagementMetricsConfig is the Schema for the costmanagementmetricsconfig
+          API
         properties:
           apiVersion:
             description: |-
@@ -39,21 +40,22 @@ spec:
           metadata:
             type: object
           spec:
-            description: KokuMetricsConfigSpec defines the desired state of KokuMetricsConfig.
+            description: CostManagementMetricsConfigSpec defines the desired state
+              of CostManagementMetricsConfig.
             properties:
               api_url:
                 default: https://console.redhat.com
                 description: |-
                   FOR DEVELOPMENT ONLY.
-                  APIURL is a field of KokuMetricsConfig to represent the url of the API endpoint for service interaction.
+                  APIURL is a field of CostManagementMetricsConfig to represent the url of the API endpoint for service interaction.
                   The default is `https://console.redhat.com`.
                 type: string
               authentication:
-                description: Authentication is a field of KokuMetricsConfig to represent
-                  the authentication object.
+                description: Authentication is a field of CostManagementMetricsConfig
+                  to represent the authentication object.
                 properties:
                   secret_name:
-                    description: AuthenticationSecretName is a field of KokuMetricsConfig
+                    description: AuthenticationSecretName is a field of CostManagementMetricsConfig
                       to represent the secret with the user and password used for
                       uploads.
                     type: string
@@ -61,13 +63,13 @@ spec:
                     default: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
                     description: |-
                       FOR DEVELOPMENT ONLY.
-                      TokenURL is a field of KokuMetricsConfig to represent the endpoint used to obtain the service account token.
+                      TokenURL is a field of CostManagementMetricsConfig to represent the endpoint used to obtain the service account token.
                       The default is `https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token`.
                     type: string
                   type:
                     default: token
                     description: |-
-                      AuthType is a field of KokuMetricsConfig to represent the authentication type to be used basic, service-account or token.
+                      AuthType is a field of CostManagementMetricsConfig to represent the authentication type to be used basic, service-account or token.
                       Valid values are:
                       - "basic" (deprecated) : Enables authentication using user and password from authentication secret.
                       - "service-account" : Enables authentication using client_id and client_secret from the secret containing service account information.
@@ -82,22 +84,22 @@ spec:
                 type: object
               clusterID:
                 description: |-
-                  ClusterID is a field of KokuMetricsConfig to represent the cluster UUID. Normally this value should not be
+                  ClusterID is a field of CostManagementMetricsConfig to represent the cluster UUID. Normally this value should not be
                   specified. Only set this value if the clusterID cannot be obtained from the ClusterVersion.
                 type: string
               clusterVersion:
                 description: |-
-                  ClusterVersion is a field of KokuMetricsConfig to represent the cluster version. Normally this value should not be
+                  ClusterVersion is a field of CostManagementMetricsConfig to represent the cluster version. Normally this value should not be
                   specified. Only set this value if the clusterVersion cannot be obtained from the ClusterVersion.
                 type: string
               packaging:
-                description: Packaging is a field of KokuMetricsConfig to represent
-                  the packaging object.
+                description: Packaging is a field of CostManagementMetricsConfig to
+                  represent the packaging object.
                 properties:
                   max_reports_to_store:
                     default: 30
                     description: |-
-                      MaxReports is a field of KokuMetricsConfig to represent the maximum number of reports to store.
+                      MaxReports is a field of CostManagementMetricsConfig to represent the maximum number of reports to store.
                       The default is 30 reports which corresponds to approximately 7 days worth of data given the other default values.
                     format: int64
                     minimum: 1
@@ -105,7 +107,7 @@ spec:
                   max_size_MB:
                     default: 100
                     description: |-
-                      MaxSize is a field of KokuMetricsConfig to represent the max file size in megabytes that will be compressed for upload to Ingress.
+                      MaxSize is a field of CostManagementMetricsConfig to represent the max file size in megabytes that will be compressed for upload to Ingress.
                       The default is 100.
                     format: int64
                     maximum: 100
@@ -116,20 +118,20 @@ spec:
                 - max_size_MB
                 type: object
               prometheus_config:
-                description: PrometheusConfig is a field of KokuMetricsConfig to represent
-                  the configuration of Prometheus connection.
+                description: PrometheusConfig is a field of CostManagementMetricsConfig
+                  to represent the configuration of Prometheus connection.
                 properties:
                   collect_previous_data:
                     default: true
                     description: |-
-                      CollectPreviousData is a field of KokuMetricsConfig to represent whether or not the operator will gather previous data upon KokuMetricsConfig
-                      creation. This toggle only changes operator behavior when a new KokuMetricsConfig is created. When `true`, the operator will gather all
+                      CollectPreviousData is a field of CostManagementMetricsConfig to represent whether or not the operator will gather previous data upon CostManagementMetricsConfig
+                      creation. This toggle only changes operator behavior when a new CostManagementMetricsConfig is created. When `true`, the operator will gather all
                       existing Prometheus data for the current month. The default is true.
                     type: boolean
                   context_timeout:
                     default: 120
                     description: |-
-                      ContextTimeout is a field of KokuMetricsConfig to represent how long a query to prometheus should run in seconds before timing out.
+                      ContextTimeout is a field of CostManagementMetricsConfig to represent how long a query to prometheus should run in seconds before timing out.
                       The default is 120 seconds.
                     format: int64
                     maximum: 180
@@ -138,27 +140,27 @@ spec:
                   disable_metrics_collection_cost_management:
                     default: false
                     description: |-
-                      DisableMetricsCollectionCostManagement is a field of KokuMetricsConfig to represent whether or not the operator will generate
+                      DisableMetricsCollectionCostManagement is a field of CostManagementMetricsConfig to represent whether or not the operator will generate
                       reports for cost-management metrics. The default is false.
                     type: boolean
                   disable_metrics_collection_resource_optimization:
                     default: false
                     description: |-
-                      DisableMetricsCollectionResourceOptimization is a field of KokuMetricsConfig to represent whether or not the operator will generate
+                      DisableMetricsCollectionResourceOptimization is a field of CostManagementMetricsConfig to represent whether or not the operator will generate
                       reports for resource-optimization metrics. The default is false.
                     type: boolean
                   service_address:
                     default: https://thanos-querier.openshift-monitoring.svc:9091
                     description: |-
                       FOR DEVELOPMENT ONLY.
-                      SvcAddress is a field of KokuMetricsConfig to represent the thanos-querier address.
+                      SvcAddress is a field of CostManagementMetricsConfig to represent the thanos-querier address.
                       The default is `https://thanos-querier.openshift-monitoring.svc:9091`.
                     type: string
                   skip_tls_verification:
                     default: false
                     description: |-
                       FOR DEVELOPMENT ONLY.
-                      SkipTLSVerification is a field of KokuMetricsConfig to represent if the thanos-querier endpoint must be certificate validated.
+                      SkipTLSVerification is a field of CostManagementMetricsConfig to represent if the thanos-querier endpoint must be certificate validated.
                       The default is false.
                     type: boolean
                 required:
@@ -198,20 +200,20 @@ spec:
                 - sources_path
                 type: object
               upload:
-                description: Upload is a field of KokuMetricsConfig to represent the
-                  upload object.
+                description: Upload is a field of CostManagementMetricsConfig to represent
+                  the upload object.
                 properties:
                   ingress_path:
                     default: /api/ingress/v1/upload
                     description: |-
                       FOR DEVELOPMENT ONLY.
-                      IngressAPIPath is a field of KokuMetricsConfig to represent the path of the Ingress API service.
+                      IngressAPIPath is a field of CostManagementMetricsConfig to represent the path of the Ingress API service.
                       The default is `/api/ingress/v1/upload`.
                     type: string
                   upload_cycle:
                     default: 360
                     description: |-
-                      UploadCycle is a field of KokuMetricsConfig to represent the number of minutes between each upload schedule.
+                      UploadCycle is a field of CostManagementMetricsConfig to represent the number of minutes between each upload schedule.
                       The default is 360 min (6 hours).
                     format: int64
                     minimum: 0
@@ -219,20 +221,20 @@ spec:
                   upload_toggle:
                     default: true
                     description: |-
-                      UploadToggle is a field of KokuMetricsConfig to represent if the operator is installed in a restricted-network.
+                      UploadToggle is a field of CostManagementMetricsConfig to represent if the operator is installed in a restricted-network.
                       If `false`, the operator will not upload to console.redhat.com or check/create sources.
                       The default is true.
                     type: boolean
                   upload_wait:
-                    description: UploadWait is a field of KokuMetricsConfig to represent
-                      the time to wait before sending an upload.
+                    description: UploadWait is a field of CostManagementMetricsConfig
+                      to represent the time to wait before sending an upload.
                     format: int64
                     minimum: 0
                     type: integer
                   validate_cert:
                     default: true
-                    description: ValidateCert is a field of KokuMetricsConfig to represent
-                      if the Ingress endpoint must be certificate validated.
+                    description: ValidateCert is a field of CostManagementMetricsConfig
+                      to represent if the Ingress endpoint must be certificate validated.
                     type: boolean
                 required:
                 - ingress_path
@@ -241,8 +243,8 @@ spec:
                 - validate_cert
                 type: object
               volume_claim_template:
-                description: VolumeClaimTemplate is a field of KokuMetricsConfig to
-                  represent a PVC template.
+                description: VolumeClaimTemplate is a field of CostManagementMetricsConfig
+                  to represent a PVC template.
                 properties:
                   apiVersion:
                     description: |-
@@ -303,6 +305,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                       dataSource:
                         description: |-
                           dataSource field can be used to specify either:
@@ -442,11 +445,13 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                  x-kubernetes-list-type: atomic
                               required:
                               - key
                               - operator
                               type: object
                             type: array
+                            x-kubernetes-list-type: atomic
                           matchLabels:
                             additionalProperties:
                               type: string
@@ -474,8 +479,8 @@ spec:
                           If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                           set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                           exists.
-                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                          (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                          More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                          (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                         type: string
                       volumeMode:
                         description: |-
@@ -496,108 +501,109 @@ spec:
             - upload
             type: object
           status:
-            description: KokuMetricsConfigStatus defines the observed state of KokuMetricsConfig.
+            description: CostManagementMetricsConfigStatus defines the observed state
+              of CostManagementMetricsConfig.
             properties:
               api_url:
-                description: APIURL is a field of KokuMetricsConfig to represent the
-                  url of the API endpoint for service interaction.
+                description: APIURL is a field of CostManagementMetricsConfig to represent
+                  the url of the API endpoint for service interaction.
                 type: string
               authentication:
-                description: Authentication is a field of KokuMetricsConfig to represent
-                  the authentication status.
+                description: Authentication is a field of CostManagementMetricsConfig
+                  to represent the authentication status.
                 properties:
                   credentials_found:
-                    description: AuthenticationCredentialsFound is a field of KokuMetricsConfig
+                    description: AuthenticationCredentialsFound is a field of CostManagementMetricsConfig
                       to represent if used for uploads were found.
                     type: boolean
                   deprecation_notice:
-                    description: DeprecationNotice is a field of KokuMetricsConfig
+                    description: DeprecationNotice is a field of CostManagementMetricsConfig
                       to represent a deprecation notice.
                     type: string
                   error:
-                    description: AuthErrorMessage is a field of KokuMetricsConfig
+                    description: AuthErrorMessage is a field of CostManagementMetricsConfig
                       to represent an `invalid credentials` error message.
                     type: string
                   last_credential_verification_time:
-                    description: LastVerificationTime is a field of KokuMetricsConfig
+                    description: LastVerificationTime is a field of CostManagementMetricsConfig
                       to represent the last time credentials were verified.
                     format: date-time
                     nullable: true
                     type: string
                   secret_name:
-                    description: AuthenticationSecretName is a field of KokuMetricsConfig
+                    description: AuthenticationSecretName is a field of CostManagementMetricsConfig
                       to represent the secret with the user and password used for
                       uploads.
                     type: string
                   token_url:
-                    description: TokenURL is a field of KokuMetricsConfig to represent
-                      the url used to generate a service account token.
+                    description: TokenURL is a field of CostManagementMetricsConfig
+                      to represent the url used to generate a service account token.
                     type: string
                   type:
-                    description: AuthType is a field of KokuMetricsConfig to represent
-                      the authentication type to be used basic, service-account or
-                      token.
+                    description: AuthType is a field of CostManagementMetricsConfig
+                      to represent the authentication type to be used basic, service-account
+                      or token.
                     enum:
                     - token
                     - basic
                     - service-account
                     type: string
                   valid_basic_auth:
-                    description: ValidBasicAuth is a field of KokuMetricsConfig to
-                      represent if the given basic auth credentials are valid.
+                    description: ValidBasicAuth is a field of CostManagementMetricsConfig
+                      to represent if the given basic auth credentials are valid.
                     type: boolean
                 type: object
               clusterID:
-                description: ClusterID is a field of KokuMetricsConfig to represent
-                  the cluster UUID.
+                description: ClusterID is a field of CostManagementMetricsConfig to
+                  represent the cluster UUID.
                 type: string
               clusterVersion:
-                description: ClusterVersion is a field of KokuMetricsConfig to represent
-                  the cluster version.
+                description: ClusterVersion is a field of CostManagementMetricsConfig
+                  to represent the cluster version.
                 type: string
               operator_commit:
-                description: OperatorCommit is a field of KokuMetricsConfig that shows
-                  the commit hash of the operator.
+                description: OperatorCommit is a field of CostManagementMetricsConfig
+                  that shows the commit hash of the operator.
                 type: string
               packaging:
-                description: Packaging is a field of KokuMetricsConfig to represent
-                  the packaging status
+                description: Packaging is a field of CostManagementMetricsConfig to
+                  represent the packaging status
                 properties:
                   error:
-                    description: PackagingError is a field of KokuMetricsConfig to
-                      represent the error encountered packaging the reports.
+                    description: PackagingError is a field of CostManagementMetricsConfig
+                      to represent the error encountered packaging the reports.
                     type: string
                   last_successful_packaging_time:
-                    description: LastSuccessfulPackagingTime is a field of KokuMetricsConfig
+                    description: LastSuccessfulPackagingTime is a field of CostManagementMetricsConfig
                       that shows the time of the last successful file packaging.
                     format: date-time
                     nullable: true
                     type: string
                   max_reports_to_store:
-                    description: MaxReports is a field of KokuMetricsConfig to represent
-                      the maximum number of reports to store.
+                    description: MaxReports is a field of CostManagementMetricsConfig
+                      to represent the maximum number of reports to store.
                     format: int64
                     type: integer
                   max_size_MB:
-                    description: MaxSize is a field of KokuMetricsConfig to represent
-                      the max file size in megabytes that will be compressed for upload
-                      to Ingress.
+                    description: MaxSize is a field of CostManagementMetricsConfig
+                      to represent the max file size in megabytes that will be compressed
+                      for upload to Ingress.
                     format: int64
                     type: integer
                   number_reports_stored:
-                    description: ReportCount is a field of KokuMetricsConfig to represent
-                      the number of reports in storage.
+                    description: ReportCount is a field of CostManagementMetricsConfig
+                      to represent the number of reports in storage.
                     format: int64
                     type: integer
                   packaged_files:
-                    description: PackagedFiles is a field of KokuMetricsConfig to
-                      represent the list of file packages in storage.
+                    description: PackagedFiles is a field of CostManagementMetricsConfig
+                      to represent the list of file packages in storage.
                     items:
                       type: string
                     type: array
                 type: object
               persistent_volume_claim:
-                description: PersistentVolumeClaim is a field of KokuMetricsConfig
+                description: PersistentVolumeClaim is a field of CostManagementMetricsConfig
                   to represent a PVC.
                 properties:
                   apiVersion:
@@ -659,6 +665,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: atomic
                       dataSource:
                         description: |-
                           dataSource field can be used to specify either:
@@ -798,11 +805,13 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                  x-kubernetes-list-type: atomic
                               required:
                               - key
                               - operator
                               type: object
                             type: array
+                            x-kubernetes-list-type: atomic
                           matchLabels:
                             additionalProperties:
                               type: string
@@ -830,8 +839,8 @@ spec:
                           If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                           set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                           exists.
-                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                          (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                          More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                          (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                         type: string
                       volumeMode:
                         description: |-
@@ -848,11 +857,11 @@ spec:
                 description: Prometheus represents the status of premetheus queries.
                 properties:
                   configuration_error:
-                    description: ConfigError is a field of KokuMetricsConfigStatus
+                    description: ConfigError is a field of CostManagementMetricsConfigStatus
                       to represent errors during prometheus configuration.
                     type: string
                   context_timeout:
-                    description: ContextTimeout is a field of KokuMetricsConfigState
+                    description: ContextTimeout is a field of CostManagementMetricsConfigState
                       to represent how long a query to prometheus should run in seconds
                       before timing out.
                     format: int64
@@ -860,23 +869,23 @@ spec:
                   disabled_metrics_collection_cost_management:
                     default: false
                     description: |-
-                      DisabledMetricsCollectionCostManagement is a field of KokuMetricsConfigStatus to represent whether or not collecting
+                      DisabledMetricsCollectionCostManagement is a field of CostManagementMetricsConfigStatus to represent whether or not collecting
                       cost-management metrics is disabled. The default is false.
                     type: boolean
                   disabled_metrics_collection_resource_optimization:
                     default: true
                     description: |-
-                      DisabledMetricsCollectionResourceOptimization is a field of KokuMetricsConfigStatus to represent whether or not collecting
+                      DisabledMetricsCollectionResourceOptimization is a field of CostManagementMetricsConfigStatus to represent whether or not collecting
                       resource-optimization metrics is disabled. The default is true.
                     type: boolean
                   last_query_start_time:
-                    description: LastQueryStartTime is a field of KokuMetricsConfigStatus
+                    description: LastQueryStartTime is a field of CostManagementMetricsConfigStatus
                       to represent the last time queries were started.
                     format: date-time
                     nullable: true
                     type: string
                   last_query_success_time:
-                    description: LastQuerySuccessTime is a field of KokuMetricsConfigStatus
+                    description: LastQuerySuccessTime is a field of CostManagementMetricsConfigStatus
                       to represent the last time queries were successful.
                     format: date-time
                     nullable: true
@@ -884,26 +893,26 @@ spec:
                   previous_data_collected:
                     default: false
                     description: |-
-                      PreviousDataCollected is a field of KokuMetricsConfigStatus to represent whether or not the operator gathered the available Prometheus
-                      data upon KokuMetricsConfig creation.
+                      PreviousDataCollected is a field of CostManagementMetricsConfigStatus to represent whether or not the operator gathered the available Prometheus
+                      data upon CostManagementMetricsConfig creation.
                     type: boolean
                   prometheus_configured:
-                    description: PrometheusConfigured is a field of KokuMetricsConfigStatus
+                    description: PrometheusConfigured is a field of CostManagementMetricsConfigStatus
                       to represent if the operator is configured to connect to prometheus.
                     type: boolean
                   prometheus_connected:
-                    description: PrometheusConnected is a field of KokuMetricsConfigStatus
+                    description: PrometheusConnected is a field of CostManagementMetricsConfigStatus
                       to represent if prometheus can be queried.
                     type: boolean
                   prometheus_connection_error:
-                    description: ConnectionError is a field of KokuMetricsConfigStatus
+                    description: ConnectionError is a field of CostManagementMetricsConfigStatus
                       to represent errors during prometheus test query.
                     type: string
                   service_address:
                     description: SvcAddress is the internal thanos-querier address.
                     type: string
                   skip_tls_verification:
-                    description: SkipTLSVerification is a field of KokuMetricsConfigStatus
+                    description: SkipTLSVerification is a field of CostManagementMetricsConfigStatus
                       to represent if the thanos-querier endpoint must be certificate
                       validated.
                     type: boolean
@@ -915,20 +924,20 @@ spec:
                 description: Reports represents the status of report generation.
                 properties:
                   data_collected:
-                    description: DataCollected is a field of KokuMetricsConfigStatus
+                    description: DataCollected is a field of CostManagementMetricsConfigStatus
                       to represent whether or not data was collected for the last
                       query.
                     type: boolean
                   data_collection_message:
-                    description: DataCollectionMessage is a field of KokuMetricsConfigStatus
+                    description: DataCollectionMessage is a field of CostManagementMetricsConfigStatus
                       to represent a message associated with the data_collected status.
                     type: string
                   last_hour_queried:
-                    description: LastHourQueried is a field of KokuMetricsConfigStatus
+                    description: LastHourQueried is a field of CostManagementMetricsConfigStatus
                       to represent the time range for which metrics were last queried.
                     type: string
                   report_month:
-                    description: ReportMonth is a field of KokuMetricsConfigStatus
+                    description: ReportMonth is a field of CostManagementMetricsConfigStatus
                       to represent the month for which reports are being generated.
                     type: string
                 type: object
@@ -983,65 +992,65 @@ spec:
                     type: string
                 type: object
               upload:
-                description: Upload is a field of KokuMetricsConfig to represent the
-                  upload object.
+                description: Upload is a field of CostManagementMetricsConfig to represent
+                  the upload object.
                 properties:
                   error:
-                    description: UploadError is a field of KokuMetricsConfigStatus
+                    description: UploadError is a field of CostManagementMetricsConfigStatus
                       to represent the error encountered uploading reports.
                     type: string
                   ingress_path:
-                    description: IngressAPIPath is a field of KokuMetricsConfig to
-                      represent the path of the Ingress API service.
+                    description: IngressAPIPath is a field of CostManagementMetricsConfig
+                      to represent the path of the Ingress API service.
                     type: string
                   last_payload_files:
-                    description: LastPayloadFiles is a field of KokuMetricsConfig
+                    description: LastPayloadFiles is a field of CostManagementMetricsConfig
                       to represent the list of files in the last payload that was
                       sent.
                     items:
                       type: string
                     type: array
                   last_payload_manifest_id:
-                    description: LastPayloadManifest is a field of KokuMetricsConfig
+                    description: LastPayloadManifest is a field of CostManagementMetricsConfig
                       that shows the manifestID of the last payload.
                     type: string
                   last_payload_name:
-                    description: LastPayloadName is a field of KokuMetricsConfig that
-                      shows the name of the last payload file.
+                    description: LastPayloadName is a field of CostManagementMetricsConfig
+                      that shows the name of the last payload file.
                     type: string
                   last_payload_request_id:
-                    description: LastPayloadRequestID is a field of KokuMetricsConfig
+                    description: LastPayloadRequestID is a field of CostManagementMetricsConfig
                       that shows the insights request id of the last payload.
                     type: string
                   last_successful_upload_time:
-                    description: LastSuccessfulUploadTime is a field of KokuMetricsConfig
+                    description: LastSuccessfulUploadTime is a field of CostManagementMetricsConfig
                       that shows the time of the last successful upload.
                     format: date-time
                     nullable: true
                     type: string
                   last_upload_status:
-                    description: LastUploadStatus is a field of KokuMetricsConfig
+                    description: LastUploadStatus is a field of CostManagementMetricsConfig
                       that shows the http status of the last upload.
                     type: string
                   upload:
                     description: |-
-                      UploadToggle is a field of KokuMetricsConfig to represent if the operator should upload to console.redhat.com.
+                      UploadToggle is a field of CostManagementMetricsConfig to represent if the operator should upload to console.redhat.com.
                       The default is true
                     type: boolean
                   upload_cycle:
                     description: |-
-                      UploadCycle is a field of KokuMetricsConfig to represent the number of minutes between each upload schedule.
+                      UploadCycle is a field of CostManagementMetricsConfig to represent the number of minutes between each upload schedule.
                       The default is 360 min (6 hours).
                     format: int64
                     type: integer
                   upload_wait:
-                    description: UploadWait is a field of KokuMetricsConfig to represent
-                      the time to wait before sending an upload.
+                    description: UploadWait is a field of CostManagementMetricsConfig
+                      to represent the time to wait before sending an upload.
                     format: int64
                     type: integer
                   validate_cert:
-                    description: ValidateCert is a field of KokuMetricsConfig to represent
-                      if the Ingress endpoint must be certificate validated.
+                    description: ValidateCert is a field of CostManagementMetricsConfig
+                      to represent if the Ingress endpoint must be certificate validated.
                     type: boolean
                 type: object
             type: object

--- a/bundle/manifests/koku-metrics-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/koku-metrics-operator.clusterserviceversion.yaml
@@ -5,10 +5,10 @@ metadata:
     alm-examples: |-
       [
         {
-          "apiVersion": "koku-metrics-cfg.openshift.io/v1beta1",
-          "kind": "KokuMetricsConfig",
+          "apiVersion": "costmanagement-metrics-cfg.openshift.io/v1beta1",
+          "kind": "CostManagementMetricsConfig",
           "metadata": {
-            "name": "kokumetricscfg-sample-v1beta1"
+            "name": "costmanagementmetricscfg-sample-v1beta1"
           },
           "spec": {
             "authentication": {
@@ -39,8 +39,8 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring
     certified: "false"
-    containerImage: quay.io/project-koku/koku-metrics-operator@sha256:c1b430cb1d699289c05fc1944d06bd6e6d09a886ab15a4f7b01f779b8ffef9b7
-    createdAt: "2024-11-05T20:59:20Z"
+    containerImage: quay.io/project-koku/koku-metrics-operator@sha256:6881531e66c4c11c6a8bd60e535040d5c5974848dc6446297c1d9a5feef6f864
+    createdAt: "2025-06-05T14:45:42Z"
     description: A Golang-based OpenShift Operator that generates and uploads OpenShift usage metrics to cost management.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -52,9 +52,48 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
+    operatorframework.io/initialization-resource: |-
+      {
+        "apiVersion": "costmanagement-metrics-cfg.openshift.io/v1beta1",
+        "kind": "CostManagementMetricsConfig",
+        "metadata": {
+          "name": "costmanagementmetricscfg-sample-v1beta1"
+        },
+        "spec": {
+          "authentication": {
+            "token_url": "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token",
+            "type": "token"
+          },
+          "api_url": "https://console.redhat.com/",
+          "packaging": {
+            "max_reports_to_store": 30,
+            "max_size_MB": 100
+          },
+          "upload": {
+            "ingress_path": "/api/ingress/v1/upload",
+            "upload_cycle": 360,
+            "upload_toggle": true,
+            "validate_cert": true
+          },
+          "prometheus_config": {
+            "collect_previous_data": true,
+            "context_timeout": 120,
+            "disable_metrics_collection_cost_management": false,
+            "disable_metrics_collection_resource_optimization": false,
+            "service_address": "https://thanos-querier.openshift-monitoring.svc:9091",
+            "skip_tls_verification": false
+          },
+          "source": {
+            "check_cycle": 1440,
+            "create_source": false,
+            "name": "",
+            "sources_path": "/api/sources/v1.0/"
+          }
+        }
+      }
     operatorframework.io/suggested-namespace: koku-metrics-operator
     operators.openshift.io/infrastructure-features: '["disconnected", "proxy-aware"]'
-    operators.operatorframework.io/builder: operator-sdk-v1.35.0
+    operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/project-koku/koku-metrics-operator
     support: Cost Management
@@ -64,16 +103,16 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: koku-metrics-operator.v3.3.2
+  name: koku-metrics-operator.v4.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-      - description: KokuMetricsConfig is the Schema for the kokumetricsconfig API
-        displayName: Koku Metrics Config
-        kind: KokuMetricsConfig
-        name: kokumetricsconfigs.koku-metrics-cfg.openshift.io
+      - description: CostManagementMetricsConfig is the Schema for the costmanagementmetricsconfig API
+        displayName: Cost Management Metrics Config
+        kind: CostManagementMetricsConfig
+        name: costmanagementmetricsconfigs.costmanagement-metrics-cfg.openshift.io
         version: v1beta1
   description: |
     # Koku Metrics Operator
@@ -96,6 +135,47 @@ spec:
     * The operator can create an integration in console.redhat.com. An integration is required for Cost Management to process the uploaded packages.
     * PersistentVolumeClaim (PVC) configuration: The KokuMetricsConfig CR can accept a PVC definition and the operator will create and mount the PVC. If one is not provided, a default PVC will be created.
     * Restricted network installation: this operator can function on a restricted network. In this mode, the operator stores the packaged reports for manual retrieval.
+
+    ## New in v4.0.0:
+    * **Virtual Machine Metrics:** Adds capabilities for collecting metrics and generating reports for running virtual machines within your OpenShift environment.
+    * **Progress towards FIPS 140 Compliance:** The operator is using the Go Cryptographic Module v1.0.0 to progress toward FIPS 140 compliance. Although this module is not validated at the time of this release, the operator aims to meet stricter security standards when the module does successfully achieve FIPS validation.
+    * **API Name Change:** The Custom Resource Definition (CRD) for configuring the upstream `Koku Metrics Operator` was renamed from `KokuMetricsConfig` to `CostManagementMetricsConfig`.
+
+    ### NOTE:
+      * The API name change impacts only users of the upstream (community) Koku Metrics Operator.
+      * The downstream (Red Hat-supported) Cost Management Metrics Operator is not impacted by this change and users should continue using their existing configurations.
+
+    **Important Upgrade Instructions:**
+
+      If you are upgrading the upstream Koku Metrics Operator to version 4.0.0 or higher, you must manually migrate your configuration. The operator will no longer recognize existing `KokuMetricsConfig` resources.
+
+      To successfully upgrade and retain your operator's configuration, complete the following steps. You can use the provided `oc` commands replacing the angle brackets (`< >`) with your specific values:
+
+      1. Backup existing configuration (recommended):
+
+         Before you upgrade, retrieve the details of your current `KokuMetricsConfig` instance to help you recreate it with the new API name.
+
+         ```
+         oc get kokumetricsconfig -n koku-metrics-operator <your-config-name> -o yaml > koku-metrics-config-backup.yaml
+         ```
+
+      2. Delete the previous `KokuMetricsConfig` instance (recommended):
+
+          After the operator is upgraded to `version 4.0.0`, delete any existing `KokuMetricsConfig` resources.
+
+          ```
+          oc delete kokumetricsconfig -n koku-metrics-operator <your-config-name>
+          ```
+
+      3. Create the new `CostManagementMetricsConfig` instance:
+
+          Using the information from your backup (or a new configuration), create a new `CostManagementMetricsConfig` instance. Adjust the spec section based on your specific needs. For more information about configurations, [refer to the configurable parameters](#configurable-parameters).
+
+      4. Apply your new configuration:
+
+          ```
+          oc apply -f <your-costmanagementmetricsconfig-file>.yaml -n koku-metrics-operator
+          ```
 
     ## New in v3.3.2:
     * Leader election settings are now configurable via environment variables. These variables can be modified in the operator [Subscription](https://github.com/operator-framework/operator-lifecycle-manager/blob/5a01f50258003e248bd5630df0837fe0bb0f1cb7/doc/design/subscription-config.md). The values should be specified as durations in seconds in the format `<number-of-seconds>s`. The default values for `LEADER_ELECTION_LEASE_DURATION`, `LEADER_ELECTION_RENEW_DEADLINE`, and `LEADER_ELECTION_RETRY_PERIOD` are '60s', '30s', and '5s', respectively.
@@ -374,7 +454,7 @@ spec:
 
         $ curl -vvvv -F "file=@FILE_NAME.tar.gz;type=application/vnd.redhat.hccm.tar+tgz" https://console.redhat.com/api/ingress/v1/upload -H "Authorization: Bearer ${ACCESS_TOKEN}"
 
-    where `FILE_NAME` is the name of the report to upload. The `ACCESS_TOKEN` is acquired using a [service-account](https://access.redhat.com/articles/7036194).
+    where `FILE_NAME` is the name of the report to upload. The `ACCESS_TOKEN` is acquired using a service account. See documentation on [creating and managing a service account](https://docs.redhat.com/en/documentation/red_hat_customer_portal/1/html/creating_and_managing_service_accounts).
   displayName: Koku Metrics Operator
   icon:
     - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjEuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAzMDAgMzAwIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCAzMDAgMzAwOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+Cgkuc3Qwe2ZpbGw6I0VFMDAwMDt9Cjwvc3R5bGU+Cjx0aXRsZT5Db3N0LWljb248L3RpdGxlPgo8ZGVzYz5DcmVhdGVkIHdpdGggU2tldGNoLjwvZGVzYz4KPGc+Cgk8Zz4KCQk8cGF0aCBjbGFzcz0ic3QwIiBkPSJNMjM5LjAzNzAzMzEsMTE3LjI3NTE3N2MtMy4yNjU4MDgxLTQxLjk4OTA1MTgtMzguMjU2NjgzMy03NC42NDcyMDE1LTgxLjE3ODgzMy03NC42NDcyMDE1CgkJCWMtMjcuNTI2MTUzNiwwLTUzLjE4NjEyNjcsMTMuOTk2MzQ5My02OC4xMTU1NzAxLDM3LjMyMzYwMDhjLTEuODY2MTgwNCwwLTMuNzMyMzUzMi0wLjQ2NjU0NTEtNi4wNjUwNzg3LTAuNDY2NTQ1MQoJCQljLTM0LjUyNDMzMDEsMC02Mi45ODM1Nzc3LDI3Ljk5MjY5ODctNjIuOTgzNTc3Nyw2Mi45ODM1NjYzczI3Ljk5MjY5ODcsNjIuOTgzNTY2Myw2Mi45ODM1Nzc3LDYyLjk4MzU2NjNoMTYuMzI5MDcxCgkJCWMzLjczMjM2MDgsMCw2Ljk5ODE3NjYtMy4yNjU4MDgxLDYuOTk4MTc2Ni02Ljk5ODE2ODlzLTMuMjY1ODE1Ny02Ljk5ODE2ODktNi45OTgxNzY2LTYuOTk4MTY4OWgtMTYuMzI5MDcxCgkJCWMtMjcuMDU5NjEyMywwLTQ4LjUyMDY3OTUtMjEuOTI3NjI3Ni00OC41MjA2Nzk1LTQ4LjUyMDY3NTdzMjEuOTI3NjEyMy00OC41MjA2ODMzLDQ4LjUyMDY3OTUtNDguNTIwNjgzMwoJCQljMi43OTkyNzA2LDAsNS41OTg1NDEzLDAuNDY2NTQ1MSw4LjM5NzgwNDMsMC45MzMwOTAyYzIuNzk5MjcwNiwwLjQ2NjU0NTEsNi4wNjUwNzg3LTAuOTMzMDkwMiw3LjQ2NDcyMTctMy43MzIzNjA4CgkJCWMxMi4xMzAxNzI3LTIwLjk5NDUyOTcsMzQuNTI0MzMwMS0zNC4wNTc3ODg4LDU4LjMxODEyMjktMzQuMDU3Nzg4OGMzNi44NTcwNzA5LDAsNjcuMTgyNDk1MSwzMC4zMjU0MjA0LDY3LjE4MjQ5NTEsNjcuMTgyNDc5OQoJCQljMCwzLjczMjM1MzIsMy4yNjU4MDgxLDYuOTk4MTc2Niw2Ljk5ODE2ODksNi45OTgxNzY2YzE2LjMyOTA3MSwwLDI5Ljg1ODkwMiwxMy41Mjk4MDA0LDI5Ljg1ODkwMiwyOS44NTg4NzE1CgkJCXMtMTMuNTI5ODMwOSwyOS44NTg4ODY3LTI5Ljg1ODkwMiwyOS44NTg4ODY3Yy0zLjczMjM2MDgsMC02Ljk5ODE2ODksMy4yNjU4MDgxLTYuOTk4MTY4OSw2Ljk5ODE2ODkKCQkJczMuMjY1ODA4MSw2Ljk5ODE2ODksNi45OTgxNjg5LDYuOTk4MTY4OWMyNC4yNjAzMzAyLDAsNDQuMzIxNzYyMS0yMC4wNjE0MTY2LDQ0LjMyMTc2MjEtNDQuMzIxNzYyMQoJCQlDMjc2LjM2MDYyNjIsMTM5LjIwMjc4OTMsMjYwLjAzMTU1NTIsMTIwLjU0MDk5MjcsMjM5LjAzNzAzMzEsMTE3LjI3NTE3N3oiLz4KCQk8cGF0aCBjbGFzcz0ic3QwIiBkPSJNMjA2Ljg0NTQyODUsMjIwLjg0ODE3NWM3LjQ2NDcwNjQtOC44NjQzNjQ2LDExLjY2MzYyLTIwLjUyNzk4NDYsMTEuNjYzNjItMzIuNjU4MTU3MwoJCQljMC0yOC45MjU3OTY1LTIzLjMyNzI0LTUyLjI1MzAzNjUtNTIuMjUzMDM2NS01Mi4yNTMwMzY1cy01Mi4yNTMwNDQxLDIzLjMyNzI0LTUyLjI1MzA0NDEsNTIuMjUzMDM2NQoJCQlzMjMuMzI3MjQ3Niw1Mi4yNTMwNTE4LDUyLjI1MzA0NDEsNTIuMjUzMDUxOGMxMS4xOTcwODI1LDAsMjEuOTI3NjEyMy0zLjczMjM2MDgsMzAuMzI1NDI0Mi05Ljc5NzQzOTZsMzEuNzI1MDUxOSwzMC43OTE5NjE3CgkJCWMxLjM5OTYyNzcsMS4zOTk2Mjc3LDMuMjY1ODIzNCwxLjg2NjE4MDQsNS4xMzE5ODg1LDEuODY2MTgwNGMxLjg2NjE5NTcsMCwzLjczMjM2MDgtMC45MzMwNzUsNS4xMzE5ODg1LTIuMzMyNzMzMgoJCQljMi43OTkyNzA2LTIuNzk5MjU1NCwyLjc5OTI3MDYtNy40NjQ3MDY0LDAtMTAuMjYzOTc3MUwyMDYuODQ1NDI4NSwyMjAuODQ4MTc1eiBNMTI4LjQ2NTg2NjEsMTg4LjE5MDAxNzcKCQkJYzAtMjAuOTk0NTIyMSwxNy4yNjIxNzY1LTM4LjI1NjY5ODYsMzguMjU2Njk4Ni0zOC4yNTY2OTg2czM4LjI1NjY5ODYsMTcuMjYyMTc2NSwzOC4yNTY2OTg2LDM4LjI1NjY5ODYKCQkJcy0xNy4yNjIxNzY1LDM4LjI1NjY5ODYtMzguMjU2Njk4NiwzOC4yNTY2OTg2UzEyOC40NjU4NjYxLDIwOS4xODQ1Mzk4LDEyOC40NjU4NjYxLDE4OC4xOTAwMTc3eiIvPgoJPC9nPgoJPGc+CgkJPHBhdGggY2xhc3M9InN0MCIgZD0iTTE3NC4yODA2Mzk2LDE4NS44NzM2MTE1YzIuMjE2Mjc4MSwwLjY4NjUzODcsNC4xMTAwMzExLDEuODcwNzEyMyw1LjY3NjYzNTcsMy41NTI1MDU1CgkJCWMxLjU2NjYwNDYsMS42ODE4MDg1LDIuNTk4NzA5MSwzLjY0OTI2MTUsMy4wOTE3MzU4LDUuOTAyNDA0OGMwLjQ5NzYxOTYsMi4yNTMxNDMzLDAuMzYzOTk4NCw0LjUyOTMyNzQtMC40MDA4Nzg5LDYuODE5MzM1OQoJCQljLTAuOTE2OTE1OSwyLjUyMDM4NTctMi40ODM1MjA1LDQuNTI5MzEyMS00LjY5OTc5ODYsNi4wMTc1OTM0Yy0yLjIxNjI2MjgsMS40ODgyODEyLTQuNjk1MjA1NywyLjI3MTU3NTktNy40NTA1NzY4LDIuMzQ5ODk5MwoJCQl2NS41MDE1NTY0YzAsMC41MzQ0ODQ5LTAuMTcwNDcxMiwwLjk3MjIxMzctMC41MTE0NTk0LDEuMzE3Nzc5NWMtMC4zNDU1NjU4LDAuMzQ1NTgxMS0wLjc4MzI5NDcsMC41MTYwNjc1LTEuMzIyMzg3NywwLjUxNjA2NzUKCQkJaC0zLjY2NzY5NDFjLTAuNTM0NTAwMSwwLTAuOTcyMjEzNy0wLjE3MDQ4NjUtMS4zMTc3Nzk1LTAuNTE2MDY3NWMtMC4zNDA5NzI5LTAuMzQ1NTY1OC0wLjUxNjA2NzUtMC43ODMyOTQ3LTAuNTE2MDY3NS0xLjMxNzc3OTUKCQkJdi01LjUwMTU1NjRjLTMuNjY3Njk0MSwwLTYuOTg5ODIyNC0xLjE0NzI5MzEtOS45Njg2NTg0LTMuNDM3MzAxNmMtMC4zODI0NDYzLTAuMzgyNDMxLTAuNjEyODIzNS0wLjg0MzIwMDctMC42ODg4NDI4LTEuMzc3NzAwOAoJCQljLTAuMDc2MDM0NS0wLjUzNDQ4NDksMC4xMTUxODg2LTEuMDMyMTA0NSwwLjU3MzYzODktMS40ODgyNTA3bDMuODk1NzgyNS0zLjg5ODA4NjUKCQkJYzAuMzA4NzAwNi0wLjIzMDM5MjUsMC42NjgxMDYxLTAuMzgyNDMxLDEuMDkyMDEwNS0wLjQ1NjE2MTVjMC40MTkyOTYzLTAuMDc4MzIzNCwwLjgyMDE1OTksMC4wMzY4NSwxLjIwMjYwNjIsMC4zNDA5NzI5CgkJCWMxLjE0NzI5MzEsMC43NjQ4NzczLDIuNDQyMDQ3MSwxLjE0NzMwODMsMy44OTM0NjMxLDEuMTQ3MzA4M2g3LjY4MDk1NGMwLjkxNjk0NjQsMCwxLjcwMDI0MTEtMC4zMjI1NDAzLDIuMzQ5ODk5My0wLjk3MjIxMzcKCQkJYzAuNjQ5Njg4Ny0wLjY0OTY4ODcsMC45NzIyMjktMS40NzQ0NTY4LDAuOTcyMjI5LTIuNDY1MTAzMWMwLTAuNjg2NTU0LTAuMjI1NzY5LTEuMzM2MjI3NC0wLjY4NjUzODctMS45NDkwMzU2CgkJCWMtMC40NTYxNjE1LTAuNjEyODIzNS0xLjAzMjExOTgtMS4wMzIxMTk4LTEuNzE4NjQzMi0xLjI2MjQ5NjlsLTExLjgwNDg0MDEtMy40MzczMTY5CgkJCWMtMi41OTg2OTM4LTAuNzY0ODc3My00Ljc3MzUyOTEtMi4xMzc5NTQ3LTYuNTMzNjQ1Ni00LjEyODQ0ODVjLTEuNzU3ODEyNS0xLjk4NTkwMDktMi43ODc2NDM0LTQuMjc1OTI0Ny0zLjA5NDAzOTktNi44NzQ2MzM4CgkJCWMtMC4xNTIwNTM4LTIuNDQ2NjU1MywwLjMwNjM5NjUtNC43MTgyMzEyLDEuMzc1Mzk2Ny02LjgxOTMzNTljMS4wNjg5Njk3LTIuMTAxMDg5NSwyLjU5ODcwOTEtMy43ODI4ODI3LDQuNTg0NjEtNS4wNDUzNzk2CgkJCWMxLjk4NTkwMDktMS4yNTc4ODg4LDQuMjAyMTc5LTEuODg5MTI5Niw2LjY0ODg0OTUtMS44ODkxMjk2aDAuMjI1NzY5di01LjUwMTU0MTEKCQkJYzAtMC41MzQ1MDAxLDAuMTc1MDk0Ni0wLjk3MjIyOSwwLjUxNjA2NzUtMS4zMTc3OTQ4YzAuMzQ1NTY1OC0wLjM0NTU4MTEsMC43ODMyNzk0LTAuNTE2MDUyMiwxLjMxNzc3OTUtMC41MTYwNTIyaDMuNjY3Njk0MQoJCQljMC41MzkwOTMsMCwwLjk3NjgyMTksMC4xNzA0NzEyLDEuMzIyMzg3NywwLjUxNjA1MjJjMC4zNDA5ODgyLDAuMzQ1NTY1OCwwLjUxMTQ1OTQsMC43ODMyOTQ3LDAuNTExNDU5NCwxLjMxNzc5NDh2NS41MDE1NDExCgkJCWMzLjY2NzY5NDEsMCw2Ljk1NzU2NTMsMS4xNDcyOTMxLDkuODYwMzgyMSwzLjQzNzMwMTZjMC40NTYxNzY4LDAuMzgyNDQ2MywwLjcyMzQxOTIsMC44NDMyMDA3LDAuODAxNzQyNiwxLjM3NzY4NTUKCQkJYzAuMDczNzE1MiwwLjUzNDUwMDEtMC4xMTUyMDM5LDAuOTkwNjQ2NC0wLjU3MTM1MDEsMS4zNzMwNzc0bC0zLjg5ODA4NjUsNC4wMTMyNzUxCgkJCWMtMC4zMDg3MTU4LDAuMjMwMzkyNS0wLjY2ODEwNjEsMC4zODI0MzEtMS4wOTIwMTA1LDAuNDU2MTYxNWMtMC40MTkyOTYzLDAuMDc4MzIzNC0wLjgyMDE1OTksMC0xLjIwMjU5MDktMC4yMjU3NjkKCQkJYy0xLjE0MjcxNTUtMC44NDMyMDA3LTIuNDQyMDc3Ni0xLjI2MjQ5NjktMy44OTgwODY1LTEuMjYyNDk2OWgtNy42NzYzNjExYy0wLjkxNjkxNTksMC0xLjcwMDIyNTgsMC4zMjI1MjUtMi4zNDk4OTkzLDAuOTcyMjEzNwoJCQljLTAuNjQ5Njg4NywwLjY0OTY3MzUtMC45NzY4MjE5LDEuNDc0NDQxNS0wLjk3NjgyMTksMi40NjUwODc5YzAsMC42ODY1NTQsMC4yMzAzOTI1LDEuMzM2MjEyMiwwLjY5MTE0NjksMS45NDkwMzU2CgkJCWMwLjQ1NjE2MTUsMC42MTI4MjM1LDEuMDMyMTE5OCwxLjAzMjExOTgsMS43MTg2NTg0LDEuMjYyNDk2OUwxNzQuMjgwNjM5NiwxODUuODczNjExNXoiLz4KCTwvZz4KPC9nPgo8L3N2Zz4K
@@ -384,24 +464,9 @@ spec:
       clusterPermissions:
         - rules:
             - apiGroups:
-                - config.openshift.io
-              resources:
-                - clusterversions
-              verbs:
-                - get
-                - list
-                - watch
-            - apiGroups:
                 - ""
               resources:
                 - configmaps
-              verbs:
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - ""
-              resources:
                 - namespaces
               verbs:
                 - get
@@ -413,6 +478,14 @@ spec:
                 - secrets
               verbs:
                 - get
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - clusterversions
+              verbs:
+                - get
+                - list
+                - watch
             - apiGroups:
                 - monitoring.coreos.com
               resources:
@@ -475,7 +548,7 @@ spec:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.annotations['olm.targetNamespaces']
-                    image: quay.io/project-koku/koku-metrics-operator@sha256:c1b430cb1d699289c05fc1944d06bd6e6d09a886ab15a4f7b01f779b8ffef9b7
+                    image: quay.io/project-koku/koku-metrics-operator@sha256:6881531e66c4c11c6a8bd60e535040d5c5974848dc6446297c1d9a5feef6f864
                     livenessProbe:
                       httpGet:
                         path: /healthz
@@ -555,15 +628,6 @@ spec:
                 - patch
                 - delete
             - apiGroups:
-                - apps
-              resources:
-                - deployments
-              verbs:
-                - get
-                - list
-                - patch
-                - watch
-            - apiGroups:
                 - ""
               resources:
                 - configmaps
@@ -584,9 +648,18 @@ spec:
                 - update
                 - watch
             - apiGroups:
-                - koku-metrics-cfg.openshift.io
+                - apps
               resources:
-                - kokumetricsconfigs
+                - deployments
+              verbs:
+                - get
+                - list
+                - patch
+                - watch
+            - apiGroups:
+                - costmanagement-metrics-cfg.openshift.io
+              resources:
+                - costmanagementmetricsconfigs
               verbs:
                 - create
                 - delete
@@ -596,9 +669,9 @@ spec:
                 - update
                 - watch
             - apiGroups:
-                - koku-metrics-cfg.openshift.io
+                - costmanagement-metrics-cfg.openshift.io
               resources:
-                - kokumetricsconfigs/status
+                - costmanagementmetricsconfigs/status
               verbs:
                 - get
                 - patch
@@ -639,8 +712,8 @@ spec:
   minKubeVersion: 1.24.0
   provider:
     name: Red Hat
-  version: 3.3.2
+  version: 4.0.0
   relatedImages:
     - name: koku-metrics-operator
-      image: quay.io/project-koku/koku-metrics-operator@sha256:c1b430cb1d699289c05fc1944d06bd6e6d09a886ab15a4f7b01f779b8ffef9b7
-  replaces: koku-metrics-operator.v3.3.1
+      image: quay.io/project-koku/koku-metrics-operator@sha256:6881531e66c4c11c6a8bd60e535040d5c5974848dc6446297c1d9a5feef6f864
+  replaces: koku-metrics-operator.v3.3.2

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: koku-metrics-operator
   operators.operatorframework.io.bundle.channels.v1: alpha,beta
   operators.operatorframework.io.bundle.channel.default.v1: beta
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.35.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.39.2
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
   # Annotations for testing.


### PR DESCRIPTION
## Summary by Sourcery

Prepare version 4.0.0 of the koku metrics operator bundle by renaming the CRD, bumping tooling and bundle versions, adding VM metrics and FIPS compliance features, and updating the CSV for default initialization, permissions, and upgrade guidance.

New Features:
- Add support for collecting virtual machine metrics
- Progress toward FIPS 140 compliance by integrating the Go Cryptographic Module v1.0.0

Enhancements:
- Rename CRD Kind and API group from KokuMetricsConfig to CostManagementMetricsConfig
- Bump operator-sdk builder to v1.39.2, controller-gen to v0.16.5, and update bundle version to v4.0.0
- Include a default CostManagementMetricsConfig initialization resource in the CSV
- Annotate CRD list fields with x-kubernetes-list-type: atomic for schema consistency
- Update volumeAttributesClass documentation and note Beta feature gate
- Revise CSV cluster role permissions and resource rules for namespaced access

Build:
- Update Makefile PREVIOUS_VERSION to 3.3.2 and VERSION to 4.0.0
- Refresh bundle.Dockerfile and metadata annotations to use operator-sdk-v1.39.2 builder labels

Documentation:
- Document API name change and upgrade instructions in the CSV description