### PR TITLE
S390x gitHub action for unit test case execution fix

### DIFF
--- a/.github/workflows/ci-manual.yaml
+++ b/.github/workflows/ci-manual.yaml
@@ -98,7 +98,7 @@ jobs:
           script: |
             apt update -y && apt install -y make
             git clone -b ${{ github.ref_name }} ${{ github.server_url }}/${{ github.repository }} koku-zvsi-clone
-            cd koku-zvsi-clone && snap install go --classic --channel=$(grep -m 1 go go.mod | cut -d\  -f2)/stable && cd ..
+            cd koku-zvsi-clone && snap install go --classic --channel=$(grep -m 1 go go.mod | cut -d' ' -f2 | cut -d. -f1,2)/stable && cd ..
             adduser --disabled-password --gecos "" runner
             cp -r koku-zvsi-clone /home/runner/koku-zvsi-clone
             chmod -R 777 /home/runner/koku-zvsi-clone


### PR DESCRIPTION
snap has updated its channel for go version and cli needs to drop minor go version while request the install

action tested:
https://github.com/project-koku/koku-metrics-operator/actions/runs/15556341281