### PR TITLE
Renovate bot ignore package updates in go.mod and go.sum

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,9 @@
         "includePaths": [
         ".tekton/**"
         ]
-    }
+    },
+    "ignorePaths": [
+        "go.mod",
+        "go.sum"
+    ]
 }


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add ignore rule to renovate.json to prevent package updates in go.mod and go.sum