### PR TITLE
properly ignore go.mod & go.sum files and vendor dir

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,8 @@
         ]
     },
     "ignorePaths": [
-        "go.mod",
-        "go.sum"
+        "**/go.mod",
+        "**/go.sum",
+        "**/vendor/**"
     ]
 }


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Add go.mod, go.sum, and vendor/** to ignorePaths in renovate.json