### PR TITLE
[COST-6579] update payload csv file names to reflect content

### DIFF
--- a/internal/packaging/packaging.go
+++ b/internal/packaging/packaging.go
@@ -183,13 +183,13 @@ func (p *FilePackager) getManifest(archiveFiles fileTracker, filePath string, cr
 	// setup the manifest
 	manifestDate := metav1.Now()
 	var costFiles []string
-	for idx := range archiveFiles.costfiles {
-		uploadName := p.uid + "_openshift_usage_report." + strconv.Itoa(idx) + ".csv"
+	for idx, costFile := range archiveFiles.costfiles {
+		uploadName := p.createCSVUploadName(costFile, idx)
 		costFiles = append(costFiles, uploadName)
 	}
 	var rosFiles []string
-	for idx := range archiveFiles.rosfiles {
-		uploadName := p.uid + "_openshift_usage_report." + strconv.Itoa(idx) + ".csv"
+	for idx, rosFile := range archiveFiles.rosfiles {
+		uploadName := p.createCSVUploadName(rosFile, idx)
 		rosFiles = append(rosFiles, uploadName)
 	}
 	p.manifest = manifestInfo{
@@ -262,7 +262,7 @@ func (p *FilePackager) writeTarball(tarFileName, manifestFileName string, archiv
 	// add the files to the tarFile
 	for idx, filePath := range archiveFiles {
 		if strings.HasSuffix(filePath, ".csv") {
-			uploadName := p.uid + "_openshift_usage_report." + strconv.Itoa(idx) + ".csv"
+			uploadName := p.createCSVUploadName(filePath, idx)
 			if err := p.addFileToTarWriter(uploadName, filePath, tw); err != nil {
 				return fmt.Errorf("writeTarball: failed to create tar file: %v", err)
 			}
@@ -637,4 +637,12 @@ func (p *FilePackager) GetFileInfo(file string) (FileInfoManifest, error) {
 		break // exit `for` loop after processing the manifest.json
 	}
 	return fileInfo, nil
+}
+
+// createCSVUploadName creates a csv filename from the base file name that reflects file contents.
+func (p *FilePackager) createCSVUploadName(filePath string, idx int) string {
+	baseFileName := filepath.Base(filePath)
+	fileNameWithoutExt := strings.TrimSuffix(baseFileName, filepath.Ext(baseFileName))
+	uploadName := fileNameWithoutExt + "." + strconv.Itoa(idx) + ".csv"
+	return uploadName
 }

--- a/internal/packaging/packaging_test.go
+++ b/internal/packaging/packaging_test.go
@@ -560,13 +560,13 @@ func TestGetAndRenderManifest(t *testing.T) {
 			}
 			// Define the expected manifest
 			var expectedCostFiles []string
-			for idx := range csvFileNames.costfiles {
-				uploadName := testPackager.uid + "_openshift_usage_report." + strconv.Itoa(idx) + ".csv"
+			for idx, costFile := range csvFileNames.costfiles {
+				uploadName := testPackager.createCSVUploadName(costFile, idx)
 				expectedCostFiles = append(expectedCostFiles, uploadName)
 			}
 			var expectedRosFiles []string
-			for idx := range csvFileNames.rosfiles {
-				uploadName := testPackager.uid + "_openshift_usage_report." + strconv.Itoa(idx) + ".csv"
+			for idx, rosFile := range csvFileNames.rosfiles {
+				uploadName := testPackager.createCSVUploadName(rosFile, idx)
 				expectedRosFiles = append(expectedRosFiles, uploadName)
 			}
 			manifestDate := metav1.Now()


### PR DESCRIPTION
## Jira Ticket

[COST-6579](https://issues.redhat.com/browse/COST-6579)

## Description

This change updates the naming convention for csv report files packaged withing the operator's payload.

## Testing instructions

**Prerequisites:**

  * Access to an OpenShift cluster.
  * A public Quay.io repository (or other container registry) to push the operator image.


### 1. Prepare the operator image

1. Checkout feature branch

2. Build and push the operator to your quay repo.Replace `<USERNAME>` with your Quay.io username and `<TAG>` with your desired image tag
    ```sh
    make docker-buildx IMG=quay.io/<USERNAME>/koku-metrics-operator:<TAG>
    ```

### 2. Deploy the operator to your OpenShift cluster

1. login into your cluster

2. create a koku-metrics-operator namespace
    ```sh
    oc new-project koku-metrics-operator
    ```

3. Pull the image to make sure its available on your machine
    ```sh
    docker pull quay.io/<USERNAME>/koku-metrics-operator:<TAG>
    ```

4. Deploy the operator
    ```sh
    make deploy IMG=quay.io/<USERNAME>/koku-metrics-operator:<TAG>
    ```

### 3. Configure metrics collection

1. Copy the yaml below to create a costmanagementmetricsconfig.yaml file

    ```yaml
    apiVersion: costmanagement-metrics-cfg.openshift.io/v1beta1
    kind: CostManagementMetricsConfig
    metadata:
        name: costmanagementmetricscfg-sample-v1beta1
        namespace: koku-metrics-operator
    spec:
        upload:
            ingress_path: /api/ingress/v1/upload
            upload_toggle: false
            validate_cert: true
        packaging:
            max_reports_to_store: 30
            max_size_MB: 100
        api_url: 'https://console.redhat.com'
        prometheus_config:
            collect_previous_data: true
            disable_metrics_collection_cost_management: false
            disable_metrics_collection_resource_optimization: false
            service_address: 'https://thanos-querier.openshift-monitoring.svc:9091'
        authentication:
            type: token
        source:
            create_source: false
            name: ''
    ```

2. deploy the configuration
    ```sh
    oc apply -f costmanagementmetricsconfig.yaml
    ```

### 4. Verify setrics collection

1. Follow the instructions on [downloading reports from the operator](https://github.com/project-koku/koku-metrics-operator/blob/main/docs/csv-description.md#download-reports-from-the-operator--clean-up-the-pvc) to retrieve a payload and inspect that the packaged reports reflect their contents. Here's an example payload: [20250717T162226_411808-cost-mgmt.tar.gz](https://github.com/user-attachments/files/21323039/20250717T162226_411808-cost-mgmt.tar.gz)



## Summary by Sourcery

Replace generic UID-based CSV report filenames with content-reflective names derived from the original file basenames and an index

Enhancements:
- Add createCSVUploadName helper to derive upload filenames from source CSV names with an index suffix.
- Update manifest generation and tarball packaging to use the new CSV naming helper instead of the UID-based pattern

Tests:
- Update packaging tests to expect the new content-based CSV naming convention.