### PR TITLE
[COST-6603] update golang builder image to 1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.24_test AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.24 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/project-koku/koku-metrics-operator
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.24.4
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
## Summary by Sourcery

Update the Golang builder image tag to rhel_9_golang_1.24 and upgrade the Go toolchain in go.mod to 1.24.4

Build:
- Update Dockerfile to use openshift-golang-builder image rhel_9_golang_1.24
- Bump Go toolchain version in go.mod to 1.24.4