### PR TITLE
add params to operator push pipeline

### DIFF
--- a/.tekton/operator-push.yaml
+++ b/.tekton/operator-push.yaml
@@ -33,6 +33,10 @@ spec:
       value: "true"
     - name: build-source-image
       value: "true"
+    - name: prefetch-input
+      value: '{"type": "rpm", "path": "."}'
+    - name: prefetch-dev-package-managers-enabled
+      value: "true"
     - name: build-platforms
       value:
         - linux/x86_64


### PR DESCRIPTION
## Summary by Sourcery

Add new prefetch parameters to the Tekton operator-push pipeline

Enhancements:
- Introduce `prefetch-input` parameter to specify input type and path
- Introduce `prefetch-dev-package-managers-enabled` parameter to enable dev package manager prefetching