### PR TITLE
trigger pipelines on updates to go.mod and go.sum files

### DIFF
--- a/.tekton/operator-pr.yaml
+++ b/.tekton/operator-pr.yaml
@@ -11,7 +11,9 @@ metadata:
       (
         ".tekton/operator-build-pipeline.yaml".pathChanged() ||
         ".tekton/operator-pr.yaml".pathChanged() ||
-        "Dockerfile".pathChanged()
+        "Dockerfile".pathChanged() ||
+        "go.mod".pathChanged() ||
+        "go.sum".pathChanged()
       )
   creationTimestamp: null
   labels:

--- a/.tekton/operator-push.yaml
+++ b/.tekton/operator-push.yaml
@@ -10,7 +10,9 @@ metadata:
       (
         ".tekton/operator-build-pipeline.yaml".pathChanged() ||
         ".tekton/operator-push.yaml".pathChanged() ||
-        "Dockerfile".pathChanged()
+        "Dockerfile".pathChanged() ||
+        "go.mod".pathChanged() ||
+        "go.sum".pathChanged()
       )
   creationTimestamp: null
   labels:


### PR DESCRIPTION
## Summary by Sourcery

Add go.mod and go.sum file changes to the path change triggers in the operator PR and push Tekton pipeline configurations

Enhancements:
- Include go.mod and go.sum in the pathChanged conditions for the operator PR pipeline
- Include go.mod and go.sum in the pathChanged conditions for the operator push pipeline