### PR TITLE
update build commit to c736197

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -18,8 +18,8 @@ COPY bundle/metadata /metadata/
 # Openshift specific labels
 LABEL io.k8s.display-name="Cost Management Metrics Operator"
 LABEL io.k8s.description="Component required to gather metrics from Prometheus, package and upload them to the cost management service in the cloud. The operator can work in clusters connected to the Internet and air-gapped (with additional configuration and steps)"
-LABEL io.openshift.build.commit.id="2ff0caa6db959b1eb4deb75b692c2daf87e7a171"
-LABEL io.openshift.build.commit.url="https://github.com/project-koku/koku-metrics-operator/commit/2ff0caa6db959b1eb4deb75b692c2daf87e7a171"
+LABEL io.openshift.build.commit.id="c7361974c47522d07a4810fdada6be4f39ecd75d"
+LABEL io.openshift.build.commit.url="https://github.com/project-koku/koku-metrics-operator/commit/c7361974c47522d07a4810fdada6be4f39ecd75d"
 LABEL io.openshift.build.source-location="https://github.com/project-koku/koku-metrics-operator"
 LABEL io.openshift.maintainer.component="Cost Management Metrics Operator"
 LABEL io.openshift.maintainer.product="OpenShift Container Platform"


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Update io.openshift.build.commit.id and commit.url labels to new commit hash c7361974