### PR TITLE
Update Makefile and improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,10 +170,10 @@ Create the CR with the default token authentication:
 $ make deploy-cr
 ```
 
-Create the CR with basic authentication specifying a username and password:
+Create the CR with service-account authentication specifying a client_id and client_secret:
 
 ```sh
-$ make deploy-cr USER=$YOUR_USERNAME PASS=$YOUR_PASSWORD AUTH=basic
+make deploy-cr CLIENT_ID=$YOUR_CLIENT_ID CLIENT_SECRET=$YOUR_CLIENT_SECRET AUTH=service-account
 ```
 
 Review the logs for the Koku Metrics operator.


### PR DESCRIPTION
## Summary by Sourcery

Switch the authentication flow in the Makefile from basic username/password to service-account client ID/secret and streamline the downstream bundle process, and update the README accordingly.

Enhancements:
- Replace basic USER/PASS authentication with CLIENT_ID/CLIENT_SECRET service-account flow in setup-auth and add-auth targets
- Update deploy-cr and deploy-local-cr to invoke unified setup-auth and add-auth for service-account authentication
- Remove versioned bundle directory creation and copying steps in the downstream bundle generation
- Simplify bundle.Dockerfile update command comment

Documentation:
- Refresh README instructions to use CLIENT_ID and CLIENT_SECRET for service-account authentication