### PR TITLE
update renovate config to keep only required managers and ignore go dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,14 +3,21 @@
     "extends": [
         "github>konflux-ci/mintmaker-presets:group-python-poetry"
     ],
-     "tekton": {
+    "tekton": {
         "includePaths": [
-        ".tekton/**"
+            ".tekton/**"
         ]
     },
+    "enabledManagers": ["tekton", "docker"],
     "ignorePaths": [
-        "**/go.mod",
-        "**/go.sum",
-        "**/vendor/**"
-    ]
+        "go.mod",
+        "go.sum",
+        "vendor/**"
+    ],
+    "golang": {
+        "enabled": false
+    },
+    "gomod": {
+        "enabled": false
+    }
 }


### PR DESCRIPTION
## Summary by Sourcery

Streamline Renovate configuration by limiting enabled package managers to only the required ones and disabling updates for Go dependencies

Enhancements:
- Restrict Renovate to use only the necessary managers
- Ignore updates for Go dependencies