### PR TITLE
[COST-6849] generate upstream bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-PREVIOUS_VERSION ?= 4.0.0
-VERSION ?= 4.1.0
+PREVIOUS_VERSION ?= 4.1.0
+VERSION ?= 4.2.0
 
 MIN_KUBE_VERSION = 1.24.0
 MIN_OCP_VERSION = 4.12

--- a/bundle/manifests/costmanagement-metrics-cfg.openshift.io_costmanagementmetricsconfigs.yaml
+++ b/bundle/manifests/costmanagement-metrics-cfg.openshift.io_costmanagementmetricsconfigs.yaml
@@ -472,15 +472,13 @@ spec:
                           volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                           If specified, the CSI driver will create or update the volume with the attributes defined
                           in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                          it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                          will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                          If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                          will be set by the persistentvolume controller if it exists.
+                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                          this field can be reset to its previous value (including nil) to cancel the modification.
                           If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                           set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                           exists.
                           More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                          (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                         type: string
                       volumeMode:
                         description: |-
@@ -832,15 +830,13 @@ spec:
                           volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
                           If specified, the CSI driver will create or update the volume with the attributes defined
                           in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
-                          it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
-                          will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
-                          If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                          will be set by the persistentvolume controller if it exists.
+                          it can be changed after the claim is created. An empty string or nil value indicates that no
+                          VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                          this field can be reset to its previous value (including nil) to cancel the modification.
                           If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                           set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                           exists.
                           More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
-                          (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                         type: string
                       volumeMode:
                         description: |-

--- a/bundle/manifests/koku-metrics-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/koku-metrics-operator.clusterserviceversion.yaml
@@ -39,8 +39,8 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring
     certified: "false"
-    containerImage: quay.io/project-koku/koku-metrics-operator@sha256:e9f2145ab2a54e9a491c6e9082490fe3296a22a992e23f86bb8130a8bf70ca36
-    createdAt: "2025-08-05T20:59:49Z"
+    containerImage: quay.io/project-koku/koku-metrics-operator@sha256:693db9c90b286c9cc4e12810fda5b0a318a9c53c4d6d4d12f7291d5234229d36
+    createdAt: "2025-09-25T19:04:35Z"
     description: A Golang-based OpenShift Operator that generates and uploads OpenShift usage metrics to cost management.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -103,7 +103,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: koku-metrics-operator.v4.1.0
+  name: koku-metrics-operator.v4.2.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -135,6 +135,11 @@ spec:
     * The operator can create an integration in console.redhat.com. An integration is required for Cost Management to process the uploaded packages.
     * PersistentVolumeClaim (PVC) configuration: The KokuMetricsConfig CR can accept a PVC definition and the operator will create and mount the PVC. If one is not provided, a default PVC will be created.
     * Restricted network installation: this operator can function on a restricted network. In this mode, the operator stores the packaged reports for manual retrieval.
+
+    ## New in v4.2.0:
+    * Enabled gathering and reporting NVIDIA GPU metrics for resource optimization.
+    * (Bugfix) Fixed custom CA certificate validation and configuration issues.
+    * (Bugfix) Fixed issue where ROS queries were missing workload metadata for namespaces labeled only with the legacy `insights_cost_management_optimizations` label.
 
     ## New in v4.1.0:
     * Enabled gathering and reporting namespace metrics to provide more granular data for resource optimization.
@@ -553,7 +558,7 @@ spec:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.annotations['olm.targetNamespaces']
-                    image: quay.io/project-koku/koku-metrics-operator@sha256:e9f2145ab2a54e9a491c6e9082490fe3296a22a992e23f86bb8130a8bf70ca36
+                    image: quay.io/project-koku/koku-metrics-operator@sha256:693db9c90b286c9cc4e12810fda5b0a318a9c53c4d6d4d12f7291d5234229d36
                     livenessProbe:
                       httpGet:
                         path: /healthz
@@ -717,8 +722,8 @@ spec:
   minKubeVersion: 1.24.0
   provider:
     name: Red Hat
-  version: 4.1.0
+  version: 4.2.0
   relatedImages:
     - name: koku-metrics-operator
-      image: quay.io/project-koku/koku-metrics-operator@sha256:e9f2145ab2a54e9a491c6e9082490fe3296a22a992e23f86bb8130a8bf70ca36
-  replaces: koku-metrics-operator.v4.0.0
+      image: quay.io/project-koku/koku-metrics-operator@sha256:693db9c90b286c9cc4e12810fda5b0a318a9c53c4d6d4d12f7291d5234229d36
+  replaces: koku-metrics-operator.v4.1.0

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -19,23 +19,25 @@ VERSION ?= <release-version>
 After creating the github release and tag, a Quay hook should automatically pull and tag the new image. Verify this by checking for the new tag in the [Quay.io repository](https://quay.io/repository/project-koku/koku-metrics-operator?tab=tags). If the tag doesn't appear, you'll need to manually build and push the image:
 
 ```bash
-make docker-build
+make docker-buildx
 make docker-push
 ```
-
 
 
 ## Generate the release bundle
 
 **Note:** Ensure the operator image is available locally or pulled to your system so that the `operator-sdk` can correctly embed its reference within the bundle's manifests.
 
-Run the following command to generate the OLM bundle for the new operator version:
+1. Pull the operator image to your local machine using the following command:
+    ```bash
+    docker pull quay.io/project-koku/koku-metrics-operator:v$VERSION
+    ```
 
-```bash
-make bundle CHANNELS=alpha,beta DEFAULT_CHANNEL=beta
-```
-
-This command generates a new bundle inside the `bundle/` directory within your repository.
+2. Run the following command to generate the OLM bundle for the new operator version:
+    ```bash
+    make bundle CHANNELS=alpha,beta DEFAULT_CHANNEL=beta
+    ```
+    This command generates a new bundle inside the `bundle/` directory within your repository.
 
 
 ## Submit the Generated bundle to `community-operators-prod`


### PR DESCRIPTION
## Summary by Sourcery

Generate upstream OLM bundle for koku-metrics-operator v4.2.0 with GPU metrics support and bug fixes, updating manifest metadata, CRD descriptions, release documentation, and version variables.

New Features:
- Enable gathering and reporting NVIDIA GPU metrics for resource optimization.

Bug Fixes:
- Fix custom CA certificate validation and configuration issues.
- Fix missing workload metadata in ROS queries for namespaces labeled with the legacy insights_cost_management_optimizations label.

Enhancements:
- Bump operator version to v4.2.0 in CSV and Makefile, updating image digests, createdAt timestamp, and replaces field.
- Clarify PVC volumeAttributesClassName behavior in costmanagementmetricsconfigs CRD manifests.

Documentation:
- Update releasing documentation to use docker-buildx, add an explicit image pull step, and refine bundle generation instructions.