### PR TITLE
bump codecov and go versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,11 +86,10 @@ jobs:
         with:
           name: coverage
       - name: Upload coverage
-        uses: codecov/codecov-action@v4.2.0
+        uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           file: ./cover.out
           flags: unittests
           fail_ci_if_error: true
-          plugin: pycoverage  # Only run one plugin even though we don't want any to run.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM:-linux/amd64} docker.io/library/golang:1.25.7 AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} docker.io/library/golang:1.25.9 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/project-koku/koku-metrics-operator
 
-go 1.25.7
+go 1.25.9
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
### Summary
* Bump codecov/codecov-action from v4.2.0 to v5, which includes fork detection fixes.
* Bump Go version to 1.25.9.