### PR TITLE
[COST-7376] add whats new in v4.4.1 to CSV description

### DIFF
--- a/docs/csv-description.md
+++ b/docs/csv-description.md
@@ -19,6 +19,13 @@ The Koku Metrics Operator (`koku-metrics-operator`) collects the metrics require
 * PersistentVolumeClaim (PVC) configuration: The CostManagementMetricsConfig CR can accept a PVC definition and the operator will create and mount the PVC. If one is not provided, a default PVC will be created.
 * Restricted network installation: this operator can function on a restricted network. In this mode, the operator stores the packaged reports for manual retrieval.
 
+## New in v4.4.1:
+* (Bugfix) Fixed `nvidia-gpu-pod-uptime-seconds` metric to correctly report wall-clock pod uptime instead of GPU compute engine active time.
+* Added `nvidia-gpu-pod-utilization` metric to track per-pod GPU utilization over time.
+* (Bugfix) Fixed DCGM PromQL queries for clusters configured with `honor_labels=true`.
+* (Bugfix) Fixed NVIDIA MIG GPU memory capacity query to correctly scope metrics to MIG GPU instances only.
+* Updated dependencies.
+
 ## New in v4.4.0:
 * Enabled gathering and reporting NVIDIA MIG (Multi-Instance GPU) metrics for cost management.
 * Updated dependencies.


### PR DESCRIPTION
Add \"New in v4.4.1\" section to CSV description doc, covering:
- Fixed \`gpu_pod_uptime\` metric to correctly report wall-clock pod uptime
- Added \`gpu_pod_utilization\` metric
- Fixed DCGM PromQL queries for clusters with \`honor_labels=true\`
- Fixed NVIDIA MIG GPU memory capacity query
- Dependency updates

Part of the upstream 4.4.1 release ([COST-7376](https://redhat.atlassian.net/browse/COST-7376)).

Made with [Cursor](https://cursor.com)