### PR TITLE
[COST-7376] generate v4.4.1 upstream bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-PREVIOUS_VERSION ?= 4.3.1
-VERSION ?= 4.4.0
+PREVIOUS_VERSION ?= 4.4.0
+VERSION ?= 4.4.1
 
 MIN_KUBE_VERSION = 1.24.0
 MIN_OCP_VERSION = 4.12

--- a/bundle/manifests/koku-metrics-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/koku-metrics-operator.clusterserviceversion.yaml
@@ -39,8 +39,8 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Monitoring
     certified: "false"
-    containerImage: quay.io/project-koku/koku-metrics-operator@sha256:abc4888c0c7ea7f8601f8c6e240f58094f3f525d73d7c2fa2302e4c6bcc2b940
-    createdAt: "2026-04-09T13:19:35Z"
+    containerImage: quay.io/project-koku/koku-metrics-operator@sha256:3e9e9b07ba0c4228e2aa1751d6118f02521c2b71faf5542911ea5d1ab7f6560f
+    createdAt: "2026-05-26T07:49:23Z"
     description: A Golang-based OpenShift Operator that generates and uploads OpenShift usage metrics to cost management.
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -103,7 +103,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: koku-metrics-operator.v4.4.0
+  name: koku-metrics-operator.v4.4.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -130,11 +130,18 @@ spec:
 
     #### Additional Capabilities:
     * Resource Optimization metrics collection.
-    * The operator can be configured to gather all previous data within the configured retention period or a maximum of 90 days. The default data collection period is the 14 previous days. This setting is only applicable to newly created KokuMetricsConfigs.
+    * The operator can be configured to gather all previous data within the configured retention period or a maximum of 90 days. The default data collection period is the 14 previous days. This setting is only applicable to newly created CostManagementMetricsConfigs.
     * The operator can be configured to automatically upload the packaged reports to Cost Management through Red Hat Insights Ingress service.
     * The operator can create an integration in console.redhat.com. An integration is required for Cost Management to process the uploaded packages.
-    * PersistentVolumeClaim (PVC) configuration: The KokuMetricsConfig CR can accept a PVC definition and the operator will create and mount the PVC. If one is not provided, a default PVC will be created.
+    * PersistentVolumeClaim (PVC) configuration: The CostManagementMetricsConfig CR can accept a PVC definition and the operator will create and mount the PVC. If one is not provided, a default PVC will be created.
     * Restricted network installation: this operator can function on a restricted network. In this mode, the operator stores the packaged reports for manual retrieval.
+
+    ## New in v4.4.1:
+    * (Bugfix) Fixed `nvidia-gpu-pod-uptime-seconds` metric to correctly report wall-clock pod uptime instead of GPU compute engine active time.
+    * Added `nvidia-gpu-pod-utilization` metric to track per-pod GPU utilization over time.
+    * (Bugfix) Fixed DCGM PromQL queries for clusters configured with `honor_labels=true`.
+    * (Bugfix) Fixed NVIDIA MIG GPU memory capacity query to correctly scope metrics to MIG GPU instances only.
+    * Updated dependencies.
 
     ## New in v4.4.0:
     * Enabled gathering and reporting NVIDIA MIG (Multi-Instance GPU) metrics for cost management.
@@ -254,7 +261,7 @@ spec:
 
     ## Limitations and Pre-Requisites
     #### Limitations (Potential for metrics data loss)
-    * An integration **must** exist in console.redhat.com for an uploaded payload to be processed by Cost Management. The operator sends the payload to the Red Hat Insights Ingress service which usually returns successfully, but the operator does not currently confirm with Cost Management that the payload was processed. After Ingress accepts the uploaded payload, it is deleted from the operator. If the data within the payload is not processed, a gap will be introduced in the usage metrics. Data may be recollected by deleting the `KokuMetricsConfig`, creating a new `KokuMetricsConfig`, and setting `collect_previous_data: true`. This re-collection of data will gather all data stored in Prometheus, up to 90 days.
+    * An integration **must** exist in console.redhat.com for an uploaded payload to be processed by Cost Management. The operator sends the payload to the Red Hat Insights Ingress service which usually returns successfully, but the operator does not currently confirm with Cost Management that the payload was processed. After Ingress accepts the uploaded payload, it is deleted from the operator. If the data within the payload is not processed, a gap will be introduced in the usage metrics. Data may be recollected by deleting the `CostManagementMetricsConfig`, creating a new `CostManagementMetricsConfig`, and setting `collect_previous_data: true`. This re-collection of data will gather all data stored in Prometheus, up to 90 days.
 
     **Note** The following limitations are specific to operators configured to run in a restricted network:
     * The `koku-metrics-operator` will not be able to generate new reports if the PVC storage is full. If this occurs, the reports must be manually deleted from the PVC so that the operator can function as normal.
@@ -275,13 +282,13 @@ spec:
                 requests:
                   storage: 10Gi
 
-    If a different PVC should be utilized, a valid PVC should be specified in the KokuMetricsConfig CR as described in the appropriate section below. The PVC to be used may exist already, or the operator will attempt to create it.
+    If a different PVC should be utilized, a valid PVC should be specified in the CostManagementMetricsConfig CR as described in the appropriate section below. The PVC to be used may exist already, or the operator will attempt to create it.
 
     To use the default specification, the follow assumptions must be met:
     1. A default StorageClass is defined.
     2. Dynamic provisioning for that default StorageClass is enabled.
 
-    If these assumptions are not met, the operator will not deploy correctly. In these cases, storage must be manually configured. After configuring storage, a valid PVC template should be supplied in the `volume_claim_template` spec of the KokuMetricsConfig CR.
+    If these assumptions are not met, the operator will not deploy correctly. In these cases, storage must be manually configured. After configuring storage, a valid PVC template should be supplied in the `volume_claim_template` spec of the CostManagementMetricsConfig CR.
 
     ## Configurable parameters:
       * `authentication`:
@@ -291,7 +298,7 @@ spec:
         * `max_reports_to_store: 30` -> The number of reports to store when configured in air-gapped mode. The default is 30, with a minimum of 1 and no maximum. When the operator is not configured in air-gapped mode, this parameter has no effect. Reports are removed as soon as they are uploaded.
         * `max_size: 100` -> The maximum size for packaged files in Megabytes prior to compression. The default is 100, with a minimum of 1 and maximum of 100.
       * `prometheus_config`:
-        * `collect_previous_data: true` -> Toggle for collecting all available data in Prometheus **upon KokuMetricsConfig creation** (This parameter will start to appear in KokuMetricsConfigs that were created prior to v2.0.0 but will not have any effect unless the KokuMetricsConfig is deleted and recreated). The default is `true`. The operator will first look for a `retention` period in the `cluster-monitoring-config` ConfigMap in the `openshift-monitoring` namespace and gather data over this time period up to a maximum of 90 days. If this configuration is not set, the default is 14 days. (New in v2.0.0)
+        * `collect_previous_data: true` -> Toggle for collecting all available data in Prometheus **upon CostManagementMetricsConfig creation** (This parameter will start to appear in CostManagementMetricsConfigs that were created prior to v2.0.0 but will not have any effect unless the CostManagementMetricsConfig is deleted and recreated). The default is `true`. The operator will first look for a `retention` period in the `cluster-monitoring-config` ConfigMap in the `openshift-monitoring` namespace and gather data over this time period up to a maximum of 90 days. If this configuration is not set, the default is 14 days. (New in v2.0.0)
         * `disable_metrics_collection_cost_management: false` -> Toggle for disabling the collection of metrics for Cost Management. The default is false. (New in v2.0.0)
         * `disable_metrics_collection_resource_optimization: false` -> Toggle for disabling the collection of metrics for Resource Optimization. The default is false. (New in v2.0.0)
         * `context_timeout: 120` -> The time in seconds before Prometheus queries timeout due to exceeding context timeout. The default is 120, with a minimum of 10 and maximum of 180.
@@ -315,9 +322,9 @@ spec:
         * service-account auth: `client_id` and `client_secret`
 
     3. Select `Create`.
-    ##### Create the KokuMetricsConfig
-    Configure the koku-metrics-operator by creating a `KokuMetricsConfig`.
-    1. On the left navigation pane, select `Operators` -> `Installed Operators` -> `koku-metrics-operator` -> `KokuMetricsConfig` -> `Create Instance`.
+    ##### Create the CostManagementMetricsConfig
+    Configure the koku-metrics-operator by creating a `CostManagementMetricsConfig`.
+    1. On the left navigation pane, select `Operators` -> `Installed Operators` -> `koku-metrics-operator` -> `CostManagementMetricsConfig` -> `Create Instance`.
     2. For `basic` (deprecated) or `service-account` authentication, edit the following values in the spec:
         * Replace `authentication: type:` with `basic` or `service-account`.
         * Add the `secret_name` field under `authentication`, and set it equal to the name of the authentication Secret that was created above. The spec should look similar to the following:
@@ -369,9 +376,9 @@ spec:
     Within a restricted network, the operator queries prometheus to gather the necessary usage metrics, writes the query results to CSV files, and packages the reports for storage in the PVC. These reports then need to be manually downloaded from the cluster and uploaded to [console.redhat.com](https://console.redhat.com).
 
     ## Configure the koku-metrics-operator for a restricted network
-    ##### Create the KokuMetricsConfig
-    Configure the koku-metrics-operator by creating a `KokuMetricsConfig`.
-    1. On the left navigation pane, select `Operators` -> `Installed Operators` -> `koku-metrics-operator` -> `KokuMetricsConfig` -> `Create Instance`.
+    ##### Create the CostManagementMetricsConfig
+    Configure the koku-metrics-operator by creating a `CostManagementMetricsConfig`.
+    1. On the left navigation pane, select `Operators` -> `Installed Operators` -> `koku-metrics-operator` -> `CostManagementMetricsConfig` -> `Create Instance`.
     2. Specify the desired storage. If not specified, the operator will create a default Persistent Volume Claim called `koku-metrics-operator-data` with 10Gi of storage. To configure the koku-metrics-operator to use or create a different PVC, edit the following in the spec:
         * Add the desired configuration to the `volume_claim_template` field in the spec (below is only a template. Any _valid_ `PersistentVolumeClaim` may be defined here):
 
@@ -460,7 +467,7 @@ spec:
     In a restricted network, the `koku-metrics-operator` cannot automatically create an integration. This process must be done manually. In the console.redhat.com platform, open the [Integrations menu](https://console.redhat.com/settings/integrations/) to begin adding an OpenShift integration to Cost Management:
 
     Prerequisites:
-    * The cluster identifier which can be found in the KokuMetricsConfig CR, the cluster Overview page, or the cluster Help > About.
+    * The cluster identifier which can be found in the CostManagementMetricsConfig CR, the cluster Overview page, or the cluster Help > About.
 
     Creating an integration:
     1. Navigate to the Integrations menu
@@ -570,7 +577,7 @@ spec:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.annotations['olm.targetNamespaces']
-                    image: quay.io/project-koku/koku-metrics-operator@sha256:abc4888c0c7ea7f8601f8c6e240f58094f3f525d73d7c2fa2302e4c6bcc2b940
+                    image: quay.io/project-koku/koku-metrics-operator@sha256:3e9e9b07ba0c4228e2aa1751d6118f02521c2b71faf5542911ea5d1ab7f6560f
                     livenessProbe:
                       httpGet:
                         path: /healthz
@@ -734,8 +741,8 @@ spec:
   minKubeVersion: 1.24.0
   provider:
     name: Red Hat
-  version: 4.4.0
+  version: 4.4.1
   relatedImages:
     - name: koku-metrics-operator
-      image: quay.io/project-koku/koku-metrics-operator@sha256:abc4888c0c7ea7f8601f8c6e240f58094f3f525d73d7c2fa2302e4c6bcc2b940
-  replaces: koku-metrics-operator.v4.3.1
+      image: quay.io/project-koku/koku-metrics-operator@sha256:3e9e9b07ba0c4228e2aa1751d6118f02521c2b71faf5542911ea5d1ab7f6560f
+  replaces: koku-metrics-operator.v4.4.0


### PR DESCRIPTION
## Summary
- Bump \`VERSION\` to \`4.4.1\` and \`PREVIOUS_VERSION\` to \`4.4.0\` in the Makefile.
- Regenerate the upstream bundle (\`make bundle CHANNELS=alpha,beta DEFAULT_CHANNEL=beta\`) referencing the official image \`quay.io/project-koku/koku-metrics-operator:v4.4.1\`.

## Files changed
- \`Makefile\` — version bump (2 lines)
- \`bundle/manifests/\` — updated CSV

## Context
This follows the [v4.4.1 GitHub Release](https://github.com/project-koku/koku-metrics-operator/releases/tag/v4.4.1). After merge, the bundle will be submitted to \`community-operators-prod\`.

Made with [Cursor](https://cursor.com)