### PR TITLE
Add tar binary to container image for oc cp support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 # Build the manager binary
+FROM docker.io/library/alpine:3.24.1 AS tools
+RUN apk add --no-cache busybox-static
+
 FROM --platform=${BUILDPLATFORM:-linux/amd64} docker.io/library/golang:1.26.4 AS builder
 
 ARG TARGETOS
@@ -51,6 +54,7 @@ LABEL \
 
 WORKDIR /
 COPY --from=builder /workspace/manager .
+COPY --from=tools /bin/busybox.static /usr/bin/tar
 USER nonroot:nonroot
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
## Summary

Addresses: [COST-7758](https://issues.redhat.com/browse/COST-7758)

- The distroless base image has no utilities, which prevents `oc cp` / `kubectl cp` from working since they require `tar` in the container
- Adds a statically-linked busybox `tar` binary (~1MB) via an Alpine build stage, keeping the minimal distroless/static base image
- Enables copying files (e.g. metrics reports from `/tmp/koku-metrics-operator-reports`) out of running pods for debugging

## Test plan

- [x] `make fmt && make lint` passes
- [x] `make test` passes
- [x] Image builds successfully with `make docker-build`
- [x] `tar --version` returns `tar (busybox) 1.37.0` inside the container
- [ ] Deploy to cluster and verify `oc cp <pod>:/tmp/koku-metrics-operator-reports/<file> ./<file>` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)