### PR TITLE
[COST-7781] Bump ubi-micro and ubi base images (glibc security fix)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,16 +27,16 @@ RUN GIT_COMMIT=$(git rev-list -1 HEAD) && \
     CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} GOFLAGS=-mod=vendor \
     go build -ldflags "-w -s -X github.com/project-koku/koku-metrics-operator/internal/controller.GitCommit=$GIT_COMMIT" -a -o manager cmd/main.go
 
-FROM registry.redhat.io/ubi9/ubi-micro:9.8@sha256:fdf68a4f5f88cca14ae906bbec6e0fbbffe92b5b91e73e0862c961234d63b986 AS target-base
+FROM registry.redhat.io/ubi9/ubi-micro:9.8@sha256:35de56a9413112f1474e392ebc35e0cf6f0fb484c8e8877bbae59b513694b41f AS target-base
 
 # Prepare a ubi micro base with openssl and its dependencies.
-FROM registry.redhat.io/ubi9/ubi:9.8@sha256:37a15896602263cb998cd3c21919efb433adf9dbd3a7c961da5d8e3083a0db82 AS ubi-micro-build
+FROM registry.redhat.io/ubi9/ubi:9.8@sha256:8bf0e8f20737e9c8a68c8a498299e9504ab397b1b1f2837acb2fef12ec698f0e AS ubi-micro-build
 COPY --from=target-base / /mnt/rootfs
 RUN rpm --root /mnt/rootfs --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 RUN yum install --installroot /mnt/rootfs --releasever 9 --setopt install_weak_deps=false --setopt reposdir=/etc/yum.repos.d --nodocs -y coreutils-single glibc-minimal-langpack openssl; yum clean all
 RUN rm -rf /mnt/rootfs/var/cache/*
 
-FROM registry.redhat.io/ubi9/ubi-micro:9.8@sha256:fdf68a4f5f88cca14ae906bbec6e0fbbffe92b5b91e73e0862c961234d63b986 AS ubi9-micro
+FROM registry.redhat.io/ubi9/ubi-micro:9.8@sha256:35de56a9413112f1474e392ebc35e0cf6f0fb484c8e8877bbae59b513694b41f AS ubi9-micro
 COPY --from=ubi-micro-build /mnt/rootfs/ /
 
 WORKDIR /


### PR DESCRIPTION
## Summary

Bump `ubi-micro:9.8` and `ubi:9.8` base image digests to versions built after [RHSA-2026:169039](https://errata.engineering.redhat.com/advisory/169039) (Moderate: glibc security, bug fix and enhancement update) was published on 2026-06-29.

### Changes

| Image | Old digest | New digest |
|-------|-----------|------------|
| `ubi9/ubi-micro:9.8` | `sha256:fdf68a4f...` (built 2026-06-25, **before** glibc fix) | `sha256:35de56a9...` (built 2026-06-30, **after** glibc fix) |
| `ubi9/ubi:9.8` | `sha256:37a15896...` | `sha256:8bf0e8f2...` |

### Why

- `glibc-2.34-272.el9_8` (the fix for RHSA-169039) was published to UBI9 repos on **2026-06-29**
- The previous `ubi-micro:9.8` pin (`fdf68a4f`) was built on **2026-06-25**, four days before the fix
- The new pin (`35de56a9`) was built on **2026-06-30**, ensuring glibc fix is included in the base layers

Closes COST-7781

Made with [Cursor](https://cursor.com)