### PR TITLE
[COST-7997] Restrict pull-secret token auth to approved RH API urls

### DIFF
--- a/api/v1beta1/defaults.go
+++ b/api/v1beta1/defaults.go
@@ -42,9 +42,6 @@ const (
 	// OldDefaultAPIURL The old default ingress path.
 	OldDefaultAPIURL string = "https://cloud.redhat.com"
 
-	// StageAPIURL The stage environment URL.
-	StageAPIURL string = "https://console.stage.redhat.com"
-
 	// DefaultTokenURL The default path to obtain a service account access token
 	DefaultTokenURL string = "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
 )

--- a/api/v1beta1/defaults.go
+++ b/api/v1beta1/defaults.go
@@ -42,6 +42,9 @@ const (
 	// OldDefaultAPIURL The old default ingress path.
 	OldDefaultAPIURL string = "https://cloud.redhat.com"
 
+	// StageAPIURL The stage environment URL.
+	StageAPIURL string = "https://console.stage.redhat.com"
+
 	// DefaultTokenURL The default path to obtain a service account access token
 	DefaultTokenURL string = "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
 )

--- a/internal/controller/costmanagementmetricsconfig_controller.go
+++ b/internal/controller/costmanagementmetricsconfig_controller.go
@@ -101,7 +101,7 @@ type serializedAuth struct {
 	Auth string `json:"auth"`
 }
 
-// isAllowedTokenAuthURL returns true if the given URL is a known Red Hat endpoint
+// isAllowedApiUrl returns true if the given URL is a known Red Hat endpoint
 // where token authentication (pull-secret) is valid.
 func isAllowedApiUrl(apiURL string) bool {
 	switch strings.TrimRight(apiURL, "/") {
@@ -421,7 +421,7 @@ func (r *MetricsConfigReconciler) setAuthentication(ctx context.Context, authCon
 	cr.Status.Authentication.AuthenticationCredentialsFound = &trueDef
 
 	if cr.Status.Authentication.AuthType == metricscfgv1beta1.Token && !isAllowedApiUrl(cr.Status.APIURL) {
-		// do no attach the cluster pull-secret token for non-approved URLs.
+		// do not attach the cluster pull-secret token for non-approved URLs.
 		authConfig.BearerTokenString = ""
 		cr.Status.Authentication.AuthenticationCredentialsFound = &falseDef
 		err := fmt.Errorf(

--- a/internal/controller/costmanagementmetricsconfig_controller.go
+++ b/internal/controller/costmanagementmetricsconfig_controller.go
@@ -425,12 +425,9 @@ func (r *MetricsConfigReconciler) setAuthentication(ctx context.Context, authCon
 		authConfig.BearerTokenString = ""
 		cr.Status.Authentication.AuthenticationCredentialsFound = &falseDef
 		err := fmt.Errorf(
-			"token authentication is only permitted against Red Hat endpoints (%s, %s, %s); "+
-				"for custom api_url, set spec.authentication.type=service-account "+
+			"token authentication is only permitted against approved Red Hat Cost Management endpoints; " +
+				"for custom api_url, set spec.authentication.type=service-account " +
 				"and the appropriate token_url for your environment",
-			metricscfgv1beta1.DefaultAPIURL,
-			metricscfgv1beta1.OldDefaultAPIURL,
-			metricscfgv1beta1.StageAPIURL,
 		)
 		cr.Status.Authentication.AuthErrorMessage = err.Error()
 		return err

--- a/internal/controller/costmanagementmetricsconfig_controller.go
+++ b/internal/controller/costmanagementmetricsconfig_controller.go
@@ -101,6 +101,17 @@ type serializedAuth struct {
 	Auth string `json:"auth"`
 }
 
+// isAllowedTokenAuthURL returns true if the given URL is a known Red Hat endpoint
+// where token authentication (pull-secret) is valid.
+func isAllowedApiUrl(apiURL string) bool {
+	switch strings.TrimRight(apiURL, "/") {
+	case metricscfgv1beta1.DefaultAPIURL, metricscfgv1beta1.OldDefaultAPIURL, metricscfgv1beta1.StageAPIURL:
+		return true
+	default:
+		return false
+	}
+}
+
 // formatURLForDisplay extracts the hostname from a URL for user-friendly display in error messages.
 // It removes the scheme (https://) and any trailing slashes to match the style of existing error messages.
 // Returns just the host portion (e.g., "console.redhat.com" or "on-prem.example.com:8443").
@@ -408,6 +419,23 @@ func (r *MetricsConfigReconciler) setAuthentication(ctx context.Context, authCon
 	log := log.WithName("setAuthentication")
 	cr.Status.Authentication.DeprecationNotice = ""
 	cr.Status.Authentication.AuthenticationCredentialsFound = &trueDef
+
+	if cr.Status.Authentication.AuthType == metricscfgv1beta1.Token && !isAllowedApiUrl(cr.Status.APIURL) {
+		// do no attach the cluster pull-secret token for non-approved URLs.
+		authConfig.BearerTokenString = ""
+		cr.Status.Authentication.AuthenticationCredentialsFound = &falseDef
+		err := fmt.Errorf(
+			"token authentication is only permitted against Red Hat endpoints (%s, %s, %s); "+
+				"for custom api_url, set spec.authentication.type=service-account "+
+				"and the appropriate token_url for your environment",
+			metricscfgv1beta1.DefaultAPIURL,
+			metricscfgv1beta1.OldDefaultAPIURL,
+			metricscfgv1beta1.StageAPIURL,
+		)
+		cr.Status.Authentication.AuthErrorMessage = err.Error()
+		return err
+	}
+
 	if cr.Status.Authentication.AuthType == metricscfgv1beta1.Token {
 		cr.Status.Authentication.ValidBasicAuth = nil
 		cr.Status.Authentication.AuthErrorMessage = ""

--- a/internal/controller/costmanagementmetricsconfig_controller.go
+++ b/internal/controller/costmanagementmetricsconfig_controller.go
@@ -105,7 +105,7 @@ type serializedAuth struct {
 // where token authentication (pull-secret) is valid.
 func isAllowedApiUrl(apiURL string) bool {
 	switch strings.TrimRight(apiURL, "/") {
-	case metricscfgv1beta1.DefaultAPIURL, metricscfgv1beta1.OldDefaultAPIURL, metricscfgv1beta1.StageAPIURL:
+	case metricscfgv1beta1.DefaultAPIURL, metricscfgv1beta1.OldDefaultAPIURL:
 		return true
 	default:
 		return false

--- a/internal/controller/costmanagementmetricsconfig_controller_test.go
+++ b/internal/controller/costmanagementmetricsconfig_controller_test.go
@@ -56,7 +56,7 @@ var (
 	defaultCheckCycle        int64 = 1440
 	defaultUploadWait        int64 = 0
 	defaultMaxReports        int64 = 1
-	defaultAPIURL                  = "https://not-the-real-console.redhat.com"
+	defaultAPIURL                  = "https://console.redhat.com"
 	testingDir                     = dirconfig.MountPath
 )
 
@@ -343,7 +343,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", Ordered, func() {
 					SkipTLSVerification: &trueValue,
 					SvcAddress:          "https://thanos-querier.openshift-monitoring.svc:9091",
 				},
-				APIURL: "https://not-the-real-console.redhat.com",
+				APIURL: defaultAPIURL,
 			},
 		}
 		testConfigMap = &corev1.ConfigMap{
@@ -503,31 +503,6 @@ var _ = Describe("MetricsConfigController - CRD Handling", Ordered, func() {
 				Expect(fetched.Status.Upload.LastSuccessfulUploadTime.IsZero()).To(BeTrue())
 				Expect(*fetched.Status.Upload.UploadToggle).To(BeFalse())
 			})
-			It("token auth works fine", func() {
-				instCopy.Spec.APIURL = unauthorizedTS.URL
-				createObject(ctx, instCopy)
-
-				fetched := &metricscfgv1beta1.MetricsConfig{}
-
-				Eventually(func() bool {
-					_ = k8sClient.Get(ctx, types.NamespacedName{Name: instCopy.Name, Namespace: namespace}, fetched)
-					return fetched.Status.ClusterID != ""
-				}, timeout, interval).Should(BeTrue())
-
-				Expect(fetched.Status.Authentication.AuthType).To(Equal(metricscfgv1beta1.DefaultAuthenticationType))
-				Expect(fetched.Status.Authentication.AuthenticationCredentialsFound).To(BeNil())
-
-				Expect(fetched.Status.APIURL).To(Equal(unauthorizedTS.URL))
-
-				Expect(fetched.Status.Prometheus.ContextTimeout).To(Equal(&diffContextTimeout))
-
-				Expect(fetched.Status.Source.SourceDefined).To(BeNil())
-				Expect(fetched.Status.Source.LastSourceCheckTime.IsZero()).To(BeTrue())
-				Expect(fetched.Status.Source.SourceError).To(Equal(""))
-
-				Expect(fetched.Status.Upload.LastSuccessfulUploadTime.IsZero()).To(BeTrue())
-				Expect(*fetched.Status.Upload.UploadToggle).To(BeFalse())
-			})
 		})
 
 		When("cluster is connected", func() {
@@ -535,7 +510,6 @@ var _ = Describe("MetricsConfigController - CRD Handling", Ordered, func() {
 				checkPVC = true
 			})
 			It("default CR works fine", func() {
-				instCopy.Spec.APIURL = validTS.URL
 				instCopy.Spec.Source.SourceName = ""
 				createObject(ctx, instCopy)
 
@@ -549,7 +523,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", Ordered, func() {
 				Expect(fetched.Status.Authentication.AuthType).To(Equal(metricscfgv1beta1.DefaultAuthenticationType))
 				Expect(*fetched.Status.Authentication.AuthenticationCredentialsFound).To(BeTrue())
 				Expect(fetched.Status.Authentication.ValidBasicAuth).To(BeNil())
-				Expect(fetched.Status.APIURL).To(Equal(validTS.URL))
+				Expect(fetched.Status.APIURL).To(Equal(defaultAPIURL))
 				Expect(fetched.Status.ClusterID).To(Equal(clusterID))
 				Expect(fetched.Status.OperatorCommit).To(Equal(GitCommit))
 				Expect(fetched.Status.Prometheus.ContextTimeout).To(Equal(&defaultContextTimeout))
@@ -558,6 +532,27 @@ var _ = Describe("MetricsConfigController - CRD Handling", Ordered, func() {
 				Expect(fetched.Status.Source.SourceError).ToNot(Equal(""))
 				Expect(fetched.Status.Upload.UploadWait).ToNot(BeNil())
 			})
+			It("token auth should be rejected against non-Red Hat URL", func() {
+				instCopy.Spec.APIURL = unauthorizedTS.URL
+				createObject(ctx, instCopy)
+
+				fetched := &metricscfgv1beta1.MetricsConfig{}
+
+				Eventually(func() bool {
+					_ = k8sClient.Get(ctx, types.NamespacedName{Name: instCopy.Name, Namespace: namespace}, fetched)
+					return fetched.Status.Authentication.AuthErrorMessage != ""
+				}, timeout, interval).Should(BeTrue())
+
+				Expect(fetched.Status.Authentication.AuthType).To(Equal(metricscfgv1beta1.DefaultAuthenticationType))
+				Expect(*fetched.Status.Authentication.AuthenticationCredentialsFound).To(BeFalse())
+				Expect(fetched.Status.Authentication.AuthErrorMessage).To(ContainSubstring("token authentication is only permitted"))
+				Expect(fetched.Status.Authentication.AuthErrorMessage).To(ContainSubstring("service-account"))
+				Expect(fetched.Status.APIURL).To(Equal(unauthorizedTS.URL))
+				// Upload must not proceed with the cluster pull-secret against a custom URL.
+				Expect(fetched.Status.Upload.LastSuccessfulUploadTime.IsZero()).To(BeTrue())
+				Expect(fetched.Status.Upload.LastUploadStatus).To(BeEmpty())
+			})
+
 			It("upload set to false case", func() {
 				instCopy.Spec.Upload.UploadToggle = &falseValue
 				createObject(ctx, instCopy)
@@ -924,7 +919,11 @@ var _ = Describe("MetricsConfigController - CRD Handling", Ordered, func() {
 			})
 			It("tar.gz being present - upload attempt should 'succeed'", func() {
 				Expect(setup()).Should(Succeed())
+				// Custom/mock API URLs cannot use token (pull-secret) auth; use service-account for local httptest.
 				instCopy.Spec.APIURL = validTS.URL
+				instCopy.Spec.Authentication.TokenURL = validTS.URL
+				instCopy.Spec.Authentication.AuthType = metricscfgv1beta1.ServiceAccount
+				instCopy.Spec.Authentication.AuthenticationSecretName = serviceAccountSecretName
 				// Configure valid source to allow upload to proceed
 				instCopy.Spec.Source.SourceName = sourceName
 				createObject(ctx, instCopy)
@@ -991,7 +990,11 @@ var _ = Describe("MetricsConfigController - CRD Handling", Ordered, func() {
 			})
 			It("should store reports when source validation fails", func() {
 				Expect(setup()).Should(Succeed())
+				// Custom/mock API URLs cannot use token (pull-secret) auth; use service-account for local httptest.
 				instCopy.Spec.APIURL = validTS.URL
+				instCopy.Spec.Authentication.TokenURL = validTS.URL
+				instCopy.Spec.Authentication.AuthType = metricscfgv1beta1.ServiceAccount
+				instCopy.Spec.Authentication.AuthenticationSecretName = serviceAccountSecretName
 				instCopy.Spec.Source.SourceName = "non-existent-source"
 				instCopy.Spec.Source.CreateSource = &falseValue
 				createObject(ctx, instCopy)
@@ -1046,7 +1049,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", Ordered, func() {
 				Expect(fetched.Status.APIURL).To(Equal(defaultAPIURL))
 				Expect(fetched.Status.Upload.LastSuccessfulUploadTime.IsZero()).To(BeTrue())
 			})
-			It("should show on-premise URL in error message when source validation fails", func() {
+			It("should reject token auth against on-premise URL without sending pull-secret", func() {
 				Expect(setup()).Should(Succeed())
 				onPremURL := "https://on-prem-koku.example.com:8443"
 				instCopy.Spec.APIURL = onPremURL
@@ -1058,17 +1061,14 @@ var _ = Describe("MetricsConfigController - CRD Handling", Ordered, func() {
 
 				Eventually(func() bool {
 					_ = k8sClient.Get(ctx, types.NamespacedName{Name: instCopy.Name, Namespace: namespace}, fetched)
-					return fetched.Status.Upload.UploadError != ""
+					return fetched.Status.Authentication.AuthErrorMessage != ""
 				}, timeout, interval).Should(BeTrue())
 
-				// Verify error message contains the on-premise hostname with port (without https://)
-				Expect(fetched.Status.Upload.UploadError).To(ContainSubstring("on-prem-koku.example.com:8443"))
-				Expect(fetched.Status.Upload.UploadError).To(ContainSubstring("Reports are being stored until a valid source is registered at"))
-				// Verify it does NOT contain the old hardcoded message
-				Expect(fetched.Status.Upload.UploadError).ToNot(ContainSubstring("console.redhat.com"))
-
 				Expect(fetched.Status.APIURL).To(Equal(onPremURL))
-				Expect(*fetched.Status.Source.SourceDefined).To(BeFalse())
+				Expect(fetched.Status.Authentication.AuthType).To(Equal(metricscfgv1beta1.Token))
+				Expect(*fetched.Status.Authentication.AuthenticationCredentialsFound).To(BeFalse())
+				Expect(fetched.Status.Authentication.AuthErrorMessage).To(ContainSubstring("token authentication is only permitted"))
+				Expect(fetched.Status.Upload.LastUploadStatus).To(BeEmpty())
 			})
 			It("should check the last upload time in the upload status", func() {
 				Expect(setup()).Should(Succeed())

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -213,11 +213,18 @@ func handleDefault(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintln(w, "Hello, client")
 }
 
+func handleToken(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintln(w, `{"access_token":"mockAccessToken","expires_in":3600,"token_type":"Bearer"}`)
+}
+
 // Router for mock server endpoints
 func routeRequest(w http.ResponseWriter, r *http.Request) {
 	// Define mock endpoints with regex patterns (most specific first)
 	endpoints := []MockEndpoint{
 		{"POST", regexp.MustCompile(`/api/ingress/`), handleIngress},
+		// Service-account token exchange (TokenURL often points at the mock root or an SSO-like path)
+		{"POST", regexp.MustCompile(`^/$|/token|/auth/realms/`), handleToken},
 		{"GET", regexp.MustCompile(`/api/sources/.*/source_types`), handleSourceTypes},
 		{"GET", regexp.MustCompile(`/api/sources/`), handleSources},
 	}
@@ -317,10 +324,10 @@ var _ = BeforeSuite(func() {
 
 	if !useCluster {
 		defaultReconciler = &MetricsConfigReconciler{
-			Client:             k8sManager.GetClient(),
-			Scheme:             scheme.Scheme,
-			Clientset:          clientset,
-			InCluster:          true,
+			Client:     k8sManager.GetClient(),
+			Scheme:     scheme.Scheme,
+			Clientset:  clientset,
+			InCluster:  true,
 			SecretPath: os.Getenv("SECRET_ABSPATH"),
 		}
 		err := (defaultReconciler).SetupWithManager(k8sManager)

--- a/internal/controller/url_formatting_test.go
+++ b/internal/controller/url_formatting_test.go
@@ -6,8 +6,14 @@
 package controller
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
+
+	metricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
+	"github.com/project-koku/koku-metrics-operator/internal/crhchttp"
 )
 
 var _ = Describe("formatURLForDisplay", func() {
@@ -31,4 +37,44 @@ var _ = Describe("formatURLForDisplay", func() {
 		Entry("Invalid URL with colon in path - triggers fallback", "not a url ://", "not a url :/"),
 		Entry("Invalid URL with spaces - triggers fallback", "https://host with spaces", "host with spaces"),
 	)
+})
+
+var _ = Describe("isAllowedTokenAuthURL", func() {
+	DescribeTable("should identify allowed Red Hat endpoints",
+		func(url string, expected bool) {
+			Expect(isAllowedApiUrl(url)).To(Equal(expected))
+		},
+		Entry("default API URL", metricscfgv1beta1.DefaultAPIURL, true),
+		Entry("old default API URL", metricscfgv1beta1.OldDefaultAPIURL, true),
+		Entry("stage API URL", metricscfgv1beta1.StageAPIURL, true),
+		Entry("on-prem URL", "https://on-prem-koku.example.com:8443", false),
+		Entry("localhost URL", "http://localhost:8088", false),
+		Entry("empty string", "", false),
+		Entry("similar but wrong URL", "https://console.redhat.com.evil.com", false),
+		Entry("default URL with trailing slash", "https://console.redhat.com/", true),
+		Entry("stage URL with trailing slash", "https://console.stage.redhat.com/", true),
+		Entry("http instead of https", "http://console.redhat.com", false),
+	)
+})
+
+var _ = Describe("setAuthentication token URL allowlist", func() {
+	It("rejects non-approved URL and clears any stale bearer token without reading pull-secret", func() {
+		r := &MetricsConfigReconciler{}
+		authCfg := &crhchttp.AuthConfig{
+			Authentication:    metricscfgv1beta1.Token,
+			BearerTokenString: "stale-pull-secret-token",
+		}
+		cr := &metricscfgv1beta1.MetricsConfig{}
+		cr.Status.APIURL = "https://evil.example.com"
+		cr.Status.Authentication.AuthType = metricscfgv1beta1.Token
+
+		err := r.setAuthentication(context.Background(), authCfg, cr, types.NamespacedName{})
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("token authentication is only permitted"))
+		Expect(authCfg.BearerTokenString).To(BeEmpty())
+		Expect(cr.Status.Authentication.AuthenticationCredentialsFound).ToNot(BeNil())
+		Expect(*cr.Status.Authentication.AuthenticationCredentialsFound).To(BeFalse())
+		Expect(cr.Status.Authentication.AuthErrorMessage).To(ContainSubstring("service-account"))
+	})
 })

--- a/internal/controller/url_formatting_test.go
+++ b/internal/controller/url_formatting_test.go
@@ -46,13 +46,11 @@ var _ = Describe("isAllowedTokenAuthURL", func() {
 		},
 		Entry("default API URL", metricscfgv1beta1.DefaultAPIURL, true),
 		Entry("old default API URL", metricscfgv1beta1.OldDefaultAPIURL, true),
-		Entry("stage API URL", metricscfgv1beta1.StageAPIURL, true),
 		Entry("on-prem URL", "https://on-prem-koku.example.com:8443", false),
 		Entry("localhost URL", "http://localhost:8088", false),
 		Entry("empty string", "", false),
 		Entry("similar but wrong URL", "https://console.redhat.com.evil.com", false),
 		Entry("default URL with trailing slash", "https://console.redhat.com/", true),
-		Entry("stage URL with trailing slash", "https://console.stage.redhat.com/", true),
 		Entry("http instead of https", "http://console.redhat.com", false),
 	)
 })


### PR DESCRIPTION
[COST-7997](https://issues.redhat.com/browse/COST-7997)

Token authentication (cluster pull-secret) must only be used against approved Red Hat Cost Management endpoints. Custom `api_url` values require `service-account` authentication.

### Prerequisites

* Access to an OpenShift cluster (CRC is fine).
* Operator built/deployed from the `COST-7997` feature branch (image / bundle / catalog, or `make bundle-deploy`).
* `oc` CLI logged into the cluster; project `koku-metrics-operator` (or your install namespace).

### Optional: images used for e2e (CRC / arm64)

These were built and pushed during local CRC verification (Apple Silicon / `linux/arm64`). Rebuild if you need a fresher commit, or point your CatalogSource / `make bundle-deploy` at your own tags.

| Image | Tag |
| --- | --- |
| Operator | `quay.io/dnakabaa/koku-metrics-operator:v4.4.1-cost7997` |
| Bundle | `quay.io/dnakabaa/koku-metrics-operator-bundle:v4.4.1-cost7997` |
| Catalog | `quay.io/dnakabaa/test-catalog:v4.4.1-cost7997` |

Example CatalogSource:

```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: kmc-test-catalog
  namespace: koku-metrics-operator
spec:
  displayName: KMC COST-7997 Test Catalog
  sourceType: grpc
  image: quay.io/dnakabaa/test-catalog:v4.4.1-cost7997
  updateStrategy:
    registryPoll:
      interval: 1m
```

### Unit / CI

```sh
make fmt && make test
```

Confirm controller coverage for:

* Token auth rejected for non-RH `api_url`
* `isAllowedApiUrl` allowlist (prod / old / stage, trailing slash, lookalike hosts)
* Stale bearer token cleared on reject
* Mock/custom URL upload paths use service-account (not pull-secret token)

### Scenario 1: Reject — token auth + custom `api_url`

1. Apply a CR with token auth and a non-approved URL (replace any existing sample CR; do not create a second CR):

    ```yaml
    apiVersion: costmanagement-metrics-cfg.openshift.io/v1beta1
    kind: CostManagementMetricsConfig
    metadata:
      name: costmanagementmetricscfg-sample
      namespace: koku-metrics-operator
    spec:
      api_url: https://evil.example.com
      authentication:
        type: token
      upload:
        upload_toggle: true
        validate_cert: true
      packaging:
        max_reports_to_store: 3
        max_size_MB: 100
      prometheus_config:
        collect_previous_data: false
        skip_tls_verification: true
      source:
        create_source: true
        name: cost7997-reject-source
    ```

2. **Verification:**

    ```sh
    oc get costmanagementmetricsconfig costmanagementmetricscfg-sample -n koku-metrics-operator -o yaml
    oc logs -n koku-metrics-operator deploy/koku-metrics-operator --tail=100 | grep -E 'token authentication|Reconciler error'
    ```

    * `status.authentication.credentials_found` is `false`
    * `status.authentication.error` contains:
      `token authentication is only permitted against approved Red Hat Cost Management endpoints`
      and guidance to use `service-account` (no explicit URL list in the message)
    * Source check / upload against the custom URL does not proceed (`source.last_check_time` unset; no successful upload)
    * Operator logs show a reconciler error with the same message

### Scenario 2: Allow — token auth + approved `api_url`

1. Update the same CR to the default Red Hat endpoint:

    ```yaml
    apiVersion: costmanagement-metrics-cfg.openshift.io/v1beta1
    kind: CostManagementMetricsConfig
    metadata:
      name: costmanagementmetricscfg-sample
      namespace: koku-metrics-operator
    spec:
      api_url: https://console.redhat.com
      authentication:
        type: token
      upload:
        upload_toggle: true
        validate_cert: true
      packaging:
        max_reports_to_store: 3
        max_size_MB: 100
      prometheus_config:
        collect_previous_data: false
        skip_tls_verification: true
      source:
        create_source: true
        name: cost7997-crc-test
    ```

2. **Verification:**

    ```sh
    oc get costmanagementmetricsconfig costmanagementmetricscfg-sample -n koku-metrics-operator -o yaml
    ```

    * `status.authentication.credentials_found` is `true`
    * `status.authentication.error` is empty
    * With a valid cluster pull-secret, source create/check can proceed (`source_defined` / `last_check_time` as expected for your environment)

### Scenario 3: Custom `api_url` with service-account (still allowed)

1. Configure the CR with service-account auth and a custom (or mock) API URL:

    ```yaml
    spec:
      api_url: https://<custom-or-mock-endpoint>
      authentication:
        type: service-account
        secret_name: <sa-secret>
        token_url: <token-endpoint>
    ```

2. **Verification:**

    * Token-auth allowlist does **not** block this path
    * Auth proceeds via service-account credentials (not the cluster pull-secret)

### Scenario 4: Regression

* Default install (omit `api_url`, token auth) still resolves to `https://console.redhat.com` and finds credentials
* `api_url: https://cloud.redhat.com` still migrates to `https://console.redhat.com` and works with token auth

## Summary by Sourcery

Restrict use of token (cluster pull-secret) authentication to an allowlisted set of Red Hat Cost Management API endpoints and require service-account authentication for custom URLs.

Bug Fixes:
- Prevent uploads from using pull-secret token against non-approved or on-premise API URLs and ensure stale bearer tokens are cleared when token auth is rejected.

Enhancements:
- Set the default API URL to the production console.redhat.com endpoint and add explicit constants and checks for old and stage Cost Management URLs.
- Extend controller authentication logic with an API URL allowlist, improved error messaging, and tests covering allowed and rejected token-auth scenarios, including on-prem and mock endpoints.
- Update test harness HTTP routing to support service-account token exchange flows for local/mock environments.

Tests:
- Add unit and controller tests validating the API URL allowlist for token authentication, rejection behavior for non-Red Hat URLs, and service-account usage for custom/mock endpoints.