### PR TITLE
[COST-7998] Restrict prometheus service_address to in-cluster .svc urls

### DIFF
--- a/internal/collector/prometheus.go
+++ b/internal/collector/prometheus.go
@@ -91,8 +91,13 @@ func statusHelper(cr *metricscfgv1beta1.MetricsConfig, status int, err error) {
 
 type PrometheusConfigurationSetter func(ps *metricscfgv1beta1.PrometheusSpec, c *PrometheusCollector) error
 
-// IsAllowedPromSvcAddress reports whether address is an https URL whose
-// hostname is in-cluster Service DNS (.svc or .svc.cluster.local).
+const (
+	thanosQuerierSvcHost             = "thanos-querier.openshift-monitoring.svc"
+	thanosQuerierSvcClusterLocalHost = "thanos-querier.openshift-monitoring.svc.cluster.local"
+)
+
+// IsAllowedPromSvcAddress reports whether address is an https URL for the
+// OpenShift cluster-monitoring thanos-querier Service.
 func IsAllowedPromSvcAddress(address string) bool {
 	u, err := url.Parse(address)
 	if err != nil || u.Host == "" {
@@ -101,14 +106,19 @@ func IsAllowedPromSvcAddress(address string) bool {
 	if !strings.EqualFold(u.Scheme, "https") {
 		return false
 	}
-	host := u.Hostname()
-	return strings.HasSuffix(host, ".svc") || strings.HasSuffix(host, ".svc.cluster.local")
+	// DNS hostnames are case-insensitive; normalize before exact host checks.
+	switch strings.ToLower(u.Hostname()) {
+	case thanosQuerierSvcHost, thanosQuerierSvcClusterLocalHost:
+		return true
+	default:
+		return false
+	}
 }
 
 func SetPrometheusConfig(ps *metricscfgv1beta1.PrometheusSpec, c *PrometheusCollector) error {
 	// Validate before reading the SA token so a rejected address never loads credentials.
 	if !IsAllowedPromSvcAddress(ps.SvcAddress) {
-		return fmt.Errorf("service_address must be an in-cluster service URL (https with hostname ending in .svc or .svc.cluster.local); got %q", ps.SvcAddress)
+		return fmt.Errorf("service_address must be the OpenShift thanos-querier service (%s or %s); got %q", thanosQuerierSvcHost, thanosQuerierSvcClusterLocalHost, ps.SvcAddress)
 	}
 
 	pCfg := &PrometheusConfig{

--- a/internal/collector/prometheus.go
+++ b/internal/collector/prometheus.go
@@ -92,8 +92,7 @@ func statusHelper(cr *metricscfgv1beta1.MetricsConfig, status int, err error) {
 type PrometheusConfigurationSetter func(ps *metricscfgv1beta1.PrometheusSpec, c *PrometheusCollector) error
 
 // IsAllowedPromSvcAddress reports whether address is an https URL whose
-// hostname is in-cluster Service DNS (.svc or .svc.cluster.local). This prevents
-// sending the operator ServiceAccount token to arbitrary external endpoints.
+// hostname is in-cluster Service DNS (.svc or .svc.cluster.local).
 func IsAllowedPromSvcAddress(address string) bool {
 	u, err := url.Parse(address)
 	if err != nil || u.Host == "" {

--- a/internal/collector/prometheus.go
+++ b/internal/collector/prometheus.go
@@ -9,9 +9,11 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"time"
 
 	promapi "github.com/prometheus/client_golang/api"
@@ -89,7 +91,26 @@ func statusHelper(cr *metricscfgv1beta1.MetricsConfig, status int, err error) {
 
 type PrometheusConfigurationSetter func(ps *metricscfgv1beta1.PrometheusSpec, c *PrometheusCollector) error
 
+// IsAllowedPromSvcAddress reports whether address is an https URL whose
+// hostname is in-cluster Service DNS (.svc or .svc.cluster.local). This prevents
+// sending the operator ServiceAccount token to arbitrary external endpoints.
+func IsAllowedPromSvcAddress(address string) bool {
+	u, err := url.Parse(address)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	if !strings.EqualFold(u.Scheme, "https") {
+		return false
+	}
+	host := u.Hostname()
+	return strings.HasSuffix(host, ".svc") || strings.HasSuffix(host, ".svc.cluster.local")
+}
+
 func SetPrometheusConfig(ps *metricscfgv1beta1.PrometheusSpec, c *PrometheusCollector) error {
+	// Validate before reading the SA token so a rejected address never loads credentials.
+	if !IsAllowedPromSvcAddress(ps.SvcAddress) {
+		return fmt.Errorf("service_address must be an in-cluster service URL (https with hostname ending in .svc or .svc.cluster.local); got %q", ps.SvcAddress)
+	}
 
 	pCfg := &PrometheusConfig{
 		Address: ps.SvcAddress,

--- a/internal/collector/prometheus_test.go
+++ b/internal/collector/prometheus_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 var trueDef = true
 var falseDef = false
 var defaultContextTimeout = 90 * time.Second
+var promSvcAddress = metricscfgv1beta1.DefaultPrometheusSvcAddress
 
 type mappedMockPromResult map[string]*mockPromResult
 type mockPromResult struct {
@@ -558,6 +560,7 @@ func TestGetPromConn(t *testing.T) {
 			statusHelper(cr, statusConfiguration, tt.cfgErr)
 			statusHelper(cr, statusConnection, tt.conErr)
 			cr.Spec.PrometheusConfig.SkipTLSVerification = &trueDef
+			cr.Spec.PrometheusConfig.SvcAddress = promSvcAddress
 			c := &PrometheusCollector{
 				PromConn: tt.con,
 				PromCfg:  tt.cfg,
@@ -575,10 +578,77 @@ func TestGetPromConn(t *testing.T) {
 	}
 }
 
+func TestIsAllowedPrometheusServiceAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		address string
+		want    bool
+	}{
+		{
+			name:    "default thanos-querier .svc address",
+			address: promSvcAddress,
+			want:    true,
+		},
+		{
+			name:    "thanos-querier with cluster.local suffix",
+			address: "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091",
+			want:    true,
+		},
+		{
+			name:    "custom in-cluster prometheus service",
+			address: "https://prometheus.custom-monitoring.svc:9090",
+			want:    true,
+		},
+		{
+			name:    "address with trailing slash",
+			address: "https://thanos-querier.openshift-monitoring.svc:9091/",
+			want:    true,
+		},
+		{
+			name:    "CRC route address",
+			address: "https://thanos-querier-openshift-monitoring.apps-crc.testing",
+			want:    false,
+		},
+		{
+			name:    "external malicious URL",
+			address: "https://evil.example.com",
+			want:    false,
+		},
+		{
+			name:    "http scheme rejected",
+			address: "http://thanos-querier.openshift-monitoring.svc:9091",
+			want:    false,
+		},
+		{
+			name:    "empty address",
+			address: "",
+			want:    false,
+		},
+		{
+			name:    "hostname that contains svc but is not in-cluster DNS",
+			address: "https://evil.svc.attacker.com",
+			want:    false,
+		},
+		{
+			name:    "IP address rejected",
+			address: "https://192.168.1.10:9091",
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsAllowedPromSvcAddress(tt.address)
+			if got != tt.want {
+				t.Errorf("IsAllowedPromSvcAddress(%q) = %v, want %v", tt.address, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSetPrometheusConfig(t *testing.T) {
 	trueDef := true
 	ps := &metricscfgv1beta1.PrometheusSpec{
-		SvcAddress:          "svc-address",
+		SvcAddress:          promSvcAddress,
 		SkipTLSVerification: &trueDef,
 	}
 	secretsPath := "./test_files/test_secrets"
@@ -588,6 +658,7 @@ func TestSetPrometheusConfig(t *testing.T) {
 		basePath    string
 		certKey     bool
 		tokenKey    bool
+		address     string
 		want        *PrometheusConfig
 		wantedError error
 	}{
@@ -597,7 +668,7 @@ func TestSetPrometheusConfig(t *testing.T) {
 			certKey:  true,
 			tokenKey: true,
 			want: &PrometheusConfig{
-				Address:     "svc-address",
+				Address:     promSvcAddress,
 				SkipTLS:     true,
 				BearerToken: config.Secret([]byte("this-is-token-data")),
 				CAFile:      filepath.Join(secretsPath, certKey),
@@ -618,7 +689,7 @@ func TestSetPrometheusConfig(t *testing.T) {
 			certKey:  true,
 			tokenKey: true,
 			want: &PrometheusConfig{
-				Address:     "svc-address",
+				Address:     promSvcAddress,
 				SkipTLS:     true,
 				BearerToken: config.Secret([]byte("this-is-token-data")),
 				CAFile:      filepath.Join(secretsPath, certKey),
@@ -640,6 +711,14 @@ func TestSetPrometheusConfig(t *testing.T) {
 			want:        nil,
 			wantedError: errTest,
 		},
+		{
+			name:        "rejected external service_address does not require token",
+			basePath:    "",
+			tokenKey:    false,
+			address:     "https://evil.example.com",
+			want:        nil,
+			wantedError: errTest,
+		},
 	}
 	for _, tt := range setPrometheusConfigTests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -654,13 +733,20 @@ func TestSetPrometheusConfig(t *testing.T) {
 				os.Remove(filepath.Join(tt.basePath, tokenKey))
 				os.Remove(filepath.Join(tt.basePath, certKey))
 			}()
-			err := SetPrometheusConfig(ps, c)
+			spec := *ps
+			if tt.address != "" {
+				spec.SvcAddress = tt.address
+			}
+			err := SetPrometheusConfig(&spec, c)
 			got := c.PromCfg
 			if tt.wantedError == nil && err != nil {
 				t.Errorf("%s got unexpected error: %v", tt.name, err)
 			}
 			if tt.wantedError != nil && err == nil {
 				t.Errorf("%s expected error, got %v", tt.name, err)
+			}
+			if tt.address != "" && err != nil && !strings.Contains(err.Error(), "in-cluster service URL") {
+				t.Errorf("%s expected in-cluster validation error, got %v", tt.name, err)
 			}
 			if got != nil && !reflect.DeepEqual(*got, *tt.want) {
 				t.Errorf("%s got %+v want %+v", tt.name, got, tt.want)

--- a/internal/collector/prometheus_test.go
+++ b/internal/collector/prometheus_test.go
@@ -595,14 +595,39 @@ func TestIsAllowedPrometheusServiceAddress(t *testing.T) {
 			want:    true,
 		},
 		{
-			name:    "custom in-cluster prometheus service",
-			address: "https://prometheus.custom-monitoring.svc:9090",
+			name:    "thanos-querier without explicit port",
+			address: "https://thanos-querier.openshift-monitoring.svc",
 			want:    true,
 		},
 		{
 			name:    "address with trailing slash",
 			address: "https://thanos-querier.openshift-monitoring.svc:9091/",
 			want:    true,
+		},
+		{
+			name:    "uppercase scheme and hostname are allowed",
+			address: "HTTPS://THANOS-QUERIER.OPENSHIFT-MONITORING.SVC:9091",
+			want:    true,
+		},
+		{
+			name:    "mixed-case .svc.cluster.local hostname is allowed",
+			address: "https://Thanos-Querier.OpenShift-Monitoring.SVC.Cluster.Local:9091",
+			want:    true,
+		},
+		{
+			name:    "custom in-cluster prometheus service rejected",
+			address: "https://prometheus.custom-monitoring.svc:9090",
+			want:    false,
+		},
+		{
+			name:    "evil service in openshift-monitoring rejected",
+			address: "https://evil.openshift-monitoring.svc:9091",
+			want:    false,
+		},
+		{
+			name:    "other service in openshift-monitoring rejected",
+			address: "https://prometheus-k8s.openshift-monitoring.svc:9091",
+			want:    false,
 		},
 		{
 			name:    "CRC route address",
@@ -625,7 +650,7 @@ func TestIsAllowedPrometheusServiceAddress(t *testing.T) {
 			want:    false,
 		},
 		{
-			name:    "hostname that contains svc but is not in-cluster DNS",
+			name:    "hostname that contains svc but is not thanos-querier",
 			address: "https://evil.svc.attacker.com",
 			want:    false,
 		},
@@ -745,8 +770,8 @@ func TestSetPrometheusConfig(t *testing.T) {
 			if tt.wantedError != nil && err == nil {
 				t.Errorf("%s expected error, got %v", tt.name, err)
 			}
-			if tt.address != "" && err != nil && !strings.Contains(err.Error(), "in-cluster service URL") {
-				t.Errorf("%s expected in-cluster validation error, got %v", tt.name, err)
+			if tt.address != "" && err != nil && !strings.Contains(err.Error(), "thanos-querier") {
+				t.Errorf("%s expected thanos-querier validation error, got %v", tt.name, err)
 			}
 			if got != nil && !reflect.DeepEqual(*got, *tt.want) {
 				t.Errorf("%s got %+v want %+v", tt.name, got, tt.want)

--- a/internal/controller/costmanagementmetricsconfig_controller_test.go
+++ b/internal/controller/costmanagementmetricsconfig_controller_test.go
@@ -1338,6 +1338,32 @@ var _ = Describe("MetricsConfigController - CRD Handling", Ordered, func() {
 
 			Expect(fetched.Status.Prometheus.ConfigError).To(ContainSubstring("failed to get token"))
 		})
+		It("rejects external service_address before querying prometheus", func() {
+			resetReconciler(WithSecretOverride(os.Getenv("SECRET_ABSPATH")))
+
+			t := time.Now().UTC().Truncate(1 * time.Hour).Add(-1 * time.Hour)
+			timeRange := promv1.Range{
+				Start: t,
+				End:   t.Add(59*time.Minute + 59*time.Second),
+				Step:  time.Minute,
+			}
+			mockpconn.EXPECT().QueryRange(gomock.Any(), gomock.Any(), timeRange, gomock.Any()).Return(model.Matrix{}, nil, nil).Times(0)
+
+			instCopy.Spec.Upload.UploadToggle = &falseValue
+			instCopy.Spec.PrometheusConfig.SvcAddress = "https://evil.example.com"
+			createObject(ctx, instCopy)
+
+			fetched := &metricscfgv1beta1.MetricsConfig{}
+
+			Eventually(func() bool {
+				_ = k8sClient.Get(ctx, types.NamespacedName{Name: instCopy.Name, Namespace: namespace}, fetched)
+				return fetched.Status.Prometheus.ConfigError != ""
+			}, timeout, interval).Should(BeTrue())
+
+			Expect(fetched.Status.Prometheus.PrometheusConfigured).To(BeFalse())
+			Expect(fetched.Status.Prometheus.ConfigError).To(ContainSubstring("in-cluster service URL"))
+			Expect(fetched.Status.Prometheus.ConfigError).To(ContainSubstring("evil.example.com"))
+		})
 		It("successfully queried but there was no data", func() {
 			resetReconciler(WithSecretOverride(os.Getenv("SECRET_ABSPATH")))
 

--- a/internal/controller/costmanagementmetricsconfig_controller_test.go
+++ b/internal/controller/costmanagementmetricsconfig_controller_test.go
@@ -1361,7 +1361,7 @@ var _ = Describe("MetricsConfigController - CRD Handling", Ordered, func() {
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(fetched.Status.Prometheus.PrometheusConfigured).To(BeFalse())
-			Expect(fetched.Status.Prometheus.ConfigError).To(ContainSubstring("in-cluster service URL"))
+			Expect(fetched.Status.Prometheus.ConfigError).To(ContainSubstring("thanos-querier"))
 			Expect(fetched.Status.Prometheus.ConfigError).To(ContainSubstring("evil.example.com"))
 		})
 		It("successfully queried but there was no data", func() {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -317,10 +317,10 @@ var _ = BeforeSuite(func() {
 
 	if !useCluster {
 		defaultReconciler = &MetricsConfigReconciler{
-			Client:             k8sManager.GetClient(),
-			Scheme:             scheme.Scheme,
-			Clientset:          clientset,
-			InCluster:          true,
+			Client:     k8sManager.GetClient(),
+			Scheme:     scheme.Scheme,
+			Clientset:  clientset,
+			InCluster:  true,
 			SecretPath: os.Getenv("SECRET_ABSPATH"),
 		}
 		err := (defaultReconciler).SetupWithManager(k8sManager)


### PR DESCRIPTION
[COST-7998](https://issues.redhat.com/browse/COST-7998)

Runtime check: only `https` URLs with hostname ending in `.svc` or `.svc.cluster.local` are allowed (validated before the SA token is loaded).

### Prerequisites

* OpenShift cluster (CRC is fine) with the `COST-7998` build deployed
* `oc` logged in; project `koku-metrics-operator`

Optional CRC/arm64 image from local e2e: `quay.io/dnakabaa/koku-metrics-operator:v4.4.1-cost7998`

```sh
export IMG=quay.io/dnakabaa/koku-metrics-operator:v4.4.1-cost7998
make deploy IMG="$IMG"
```

### Scenario 1: Reject — external URL

```yaml
apiVersion: costmanagement-metrics-cfg.openshift.io/v1beta1
kind: CostManagementMetricsConfig
metadata:
  name: costmanagementmetricscfg-sample
  namespace: koku-metrics-operator
spec:
  authentication:
    type: token
  upload:
    upload_toggle: false
  prometheus_config:
    collect_previous_data: false
    service_address: https://evil.example.com
    skip_tls_verification: true
  source:
    create_source: false
```

**Expect:** `prometheus_configured=false`; `configuration_error` contains `in-cluster service URL` and `evil.example.com`.

```sh
oc get costmanagementmetricsconfig costmanagementmetricscfg-sample -n koku-metrics-operator -o yaml
oc logs -n koku-metrics-operator deploy/koku-metrics-operator --tail=50 | grep -E 'in-cluster|Reconciler error'
```

### Scenario 2: Allow — default `.svc`

Patch the same CR:

```yaml
spec:
  prometheus_config:
    service_address: https://thanos-querier.openshift-monitoring.svc:9091
    skip_tls_verification: true
```

**Expect:** `prometheus_configured=true`, empty `configuration_error`, `prometheus_connected=true` (when thanos is reachable).

## Summary by Sourcery

Restrict Prometheus service_address configuration to in-cluster HTTPS service URLs and ensure invalid endpoints are rejected before credentials are loaded.

Bug Fixes:
- Prevent configuring Prometheus with external, non-.svc/.svc.cluster.local, or non-HTTPS service_address values by validating the URL at runtime.

Enhancements:
- Use the default in-cluster Prometheus service address in tests and add helper logic to centralize service_address validation.

Tests:
- Add unit and controller tests verifying allowed and rejected Prometheus service_address values, including that external URLs are blocked before any Prometheus queries or token loading occur.