### PR TITLE
[COST-7999] Validate token_url before posting service-account credentials

### DIFF
--- a/internal/controller/costmanagementmetricsconfig_controller.go
+++ b/internal/controller/costmanagementmetricsconfig_controller.go
@@ -112,6 +112,24 @@ func isAllowedApiUrl(apiURL string) bool {
 	}
 }
 
+// validateTokenURL ensures service-account client credentials are only POSTed to an HTTPS endpoint.
+// When apiURL is a known Red Hat Cost Management endpoint, tokenURL must be Red Hat SSO token URL.
+func validateTokenURL(apiURL, tokenURL string) error {
+	parsed, err := url.Parse(tokenURL)
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+		return fmt.Errorf("token_url must use https with a valid host")
+	}
+	if isAllowedApiUrl(apiURL) {
+		if strings.TrimRight(tokenURL, "/") != strings.TrimRight(metricscfgv1beta1.DefaultTokenURL, "/") {
+			return fmt.Errorf(
+				"when api_url is a Red Hat Cost Management endpoint, token_url must be %s",
+				metricscfgv1beta1.DefaultTokenURL,
+			)
+		}
+	}
+	return nil
+}
+
 // formatURLForDisplay extracts the hostname from a URL for user-friendly display in error messages.
 // It removes the scheme (https://) and any trailing slashes to match the style of existing error messages.
 // Returns just the host portion (e.g., "console.redhat.com" or "on-prem.example.com:8443").
@@ -493,7 +511,13 @@ func (r *MetricsConfigReconciler) validateCredentials(ctx context.Context, handl
 
 	// Service-account authentication check
 	if cr.Spec.Authentication.AuthType == metricscfgv1beta1.ServiceAccount {
-		if err := handler.Auth.GetAccessToken(ctx, cr.Spec.Authentication.TokenURL); err != nil {
+		tokenURL := cr.Status.Authentication.TokenURL
+		if err := validateTokenURL(cr.Status.APIURL, tokenURL); err != nil {
+			log.Info(err.Error())
+			cr.Status.Authentication.AuthErrorMessage = err.Error()
+			return err
+		}
+		if err := handler.Auth.GetAccessToken(ctx, tokenURL); err != nil {
 			errorMsg := fmt.Sprintf("failed to obtain service-account token: %v", err)
 			log.Info(errorMsg)
 			cr.Status.Authentication.AuthErrorMessage = errorMsg

--- a/internal/controller/costmanagementmetricsconfig_controller_test.go
+++ b/internal/controller/costmanagementmetricsconfig_controller_test.go
@@ -330,7 +330,8 @@ var _ = Describe("MetricsConfigController - CRD Handling", Ordered, func() {
 					UploadToggle:   &trueValue,
 					UploadWait:     &defaultUploadWait,
 					IngressAPIPath: "/api/ingress/v1/upload",
-					ValidateCert:   &trueValue,
+					// false so local TLS mock servers (self-signed) are accepted
+					ValidateCert: &falseValue,
 				},
 				Source: metricscfgv1beta1.CloudDotRedHatSourceSpec{
 					CreateSource:   &falseValue,

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -267,7 +267,8 @@ func routeRequestExpiredCreds(w http.ResponseWriter, r *http.Request) {
 }
 
 var _ = BeforeSuite(func() {
-	validTS = httptest.NewServer(http.HandlerFunc(routeRequest))
+	// TLS so service-account token_url can satisfy the HTTPS requirement in tests.
+	validTS = httptest.NewTLSServer(http.HandlerFunc(routeRequest))
 	unauthorizedTS = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 	}))

--- a/internal/controller/url_formatting_test.go
+++ b/internal/controller/url_formatting_test.go
@@ -103,6 +103,8 @@ var _ = Describe("validateTokenURL", func() {
 			metricscfgv1beta1.DefaultAPIURL, "http://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token", "https"),
 		Entry("custom api + custom HTTPS Keycloak",
 			"https://on-prem-koku.example.com:8443", "https://keycloak.corp.internal/auth/realms/cost/protocol/openid-connect/token", ""),
+		Entry("custom api + RH SSO token_url still allowed",
+			"https://on-prem-koku.example.com:8443", metricscfgv1beta1.DefaultTokenURL, ""),
 		Entry("custom api + http Keycloak",
 			"https://on-prem-koku.example.com:8443", "http://keycloak.corp.internal/auth/token", "https"),
 		Entry("empty token_url host",

--- a/internal/controller/url_formatting_test.go
+++ b/internal/controller/url_formatting_test.go
@@ -14,6 +14,7 @@ import (
 
 	metricscfgv1beta1 "github.com/project-koku/koku-metrics-operator/api/v1beta1"
 	"github.com/project-koku/koku-metrics-operator/internal/crhchttp"
+	"github.com/project-koku/koku-metrics-operator/internal/sources"
 )
 
 var _ = Describe("formatURLForDisplay", func() {
@@ -74,5 +75,63 @@ var _ = Describe("setAuthentication token URL allowlist", func() {
 		Expect(cr.Status.Authentication.AuthenticationCredentialsFound).ToNot(BeNil())
 		Expect(*cr.Status.Authentication.AuthenticationCredentialsFound).To(BeFalse())
 		Expect(cr.Status.Authentication.AuthErrorMessage).To(ContainSubstring("service-account"))
+	})
+})
+
+var _ = Describe("validateTokenURL", func() {
+	DescribeTable("validates token_url based on api_url context",
+		func(apiURL, tokenURL string, expectErrSubstring string) {
+			err := validateTokenURL(apiURL, tokenURL)
+			if expectErrSubstring == "" {
+				Expect(err).ToNot(HaveOccurred())
+				return
+			}
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(expectErrSubstring))
+		},
+		Entry("RH api + default SSO",
+			metricscfgv1beta1.DefaultAPIURL, metricscfgv1beta1.DefaultTokenURL, ""),
+		Entry("RH api + default SSO with trailing slash",
+			metricscfgv1beta1.DefaultAPIURL, metricscfgv1beta1.DefaultTokenURL+"/", ""),
+		Entry("old RH api + default SSO",
+			metricscfgv1beta1.OldDefaultAPIURL, metricscfgv1beta1.DefaultTokenURL, ""),
+		Entry("RH api + attacker HTTPS token_url",
+			metricscfgv1beta1.DefaultAPIURL, "https://evil.example.com/token", "Red Hat Cost Management endpoint"),
+		Entry("RH api + lookalike SSO host",
+			metricscfgv1beta1.DefaultAPIURL, "https://sso.redhat.com.evil.com/auth/realms/redhat-external/protocol/openid-connect/token", "Red Hat Cost Management endpoint"),
+		Entry("RH api + http SSO",
+			metricscfgv1beta1.DefaultAPIURL, "http://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token", "https"),
+		Entry("custom api + custom HTTPS Keycloak",
+			"https://on-prem-koku.example.com:8443", "https://keycloak.corp.internal/auth/realms/cost/protocol/openid-connect/token", ""),
+		Entry("custom api + http Keycloak",
+			"https://on-prem-koku.example.com:8443", "http://keycloak.corp.internal/auth/token", "https"),
+		Entry("empty token_url host",
+			metricscfgv1beta1.DefaultAPIURL, "https://", "https"),
+		Entry("malformed token_url",
+			"https://on-prem-koku.example.com:8443", "://bad", "https"),
+	)
+
+	It("rejects RH api + invalid token_url in validateCredentials before token exchange", func() {
+		r := &MetricsConfigReconciler{}
+		handler := &sources.SourceHandler{
+			Auth: &crhchttp.AuthConfig{
+				Authentication: metricscfgv1beta1.ServiceAccount,
+				ServiceAccountData: crhchttp.ServiceAccountData{
+					ClientID:     "client",
+					ClientSecret: "secret",
+				},
+			},
+		}
+		cr := &metricscfgv1beta1.MetricsConfig{}
+		cr.Spec.Authentication.AuthType = metricscfgv1beta1.ServiceAccount
+		cr.Status.APIURL = metricscfgv1beta1.DefaultAPIURL
+		cr.Status.Authentication.TokenURL = "https://evil.example.com/token"
+
+		err := r.validateCredentials(context.Background(), handler, cr, 0)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Red Hat Cost Management endpoint"))
+		Expect(cr.Status.Authentication.AuthErrorMessage).To(ContainSubstring("Red Hat Cost Management endpoint"))
+		Expect(handler.Auth.BearerTokenString).To(BeEmpty())
 	})
 })


### PR DESCRIPTION
[COST-7999](https://issues.redhat.com/browse/COST-7999)

Runtime check in `validateCredentials` (before `GetAccessToken`):

* Always require `https` + valid host for `token_url`
* When `api_url` is a known RH endpoint, `token_url` must be the RH SSO URL
* Custom (on-prem) `api_url` may use any HTTPS `token_url` (e.g. customer Keycloak)

### Prerequisites

* OpenShift cluster (CRC is fine) with the `COST-7999` build deployed
* `oc` logged in; project `koku-metrics-operator`
* `upload_toggle: true` since auth validation only runs on the connected-cluster / upload path

Create a dummy service-account secret (real RH credentials are not required for Scenarios 1–2):

```sh
oc create secret generic cost7999-sa-auth -n koku-metrics-operator \
  --from-literal=client_id='cost7999-client' \
  --from-literal=client_secret='cost7999-secret' \
  --dry-run=client -o yaml | oc apply -f -
```

### Scenario 1: Reject — RH `api_url` + invalid `token_url`

```yaml
apiVersion: costmanagement-metrics-cfg.openshift.io/v1beta1
kind: CostManagementMetricsConfig
metadata:
  name: costmanagementmetricscfg-sample
  namespace: koku-metrics-operator
spec:
  api_url: https://console.redhat.com
  authentication:
    type: service-account
    secret_name: cost7999-sa-auth
    token_url: https://evil.example.com/token
  upload:
    upload_toggle: true
  prometheus_config:
    collect_previous_data: false
    skip_tls_verification: true
  source:
    create_source: false
```

```sh
oc get costmanagementmetricsconfig costmanagementmetricscfg-sample -n koku-metrics-operator -o yaml
oc logs -n koku-metrics-operator deploy/koku-metrics-operator --tail=50 | grep -E 'Red Hat Cost Management|requesting service-account|Reconciler error'
```

**Expect:**

* `status.authentication.error` contains  
  `when api_url is a Red Hat Cost Management endpoint, token_url must be https://sso.redhat.com/...`
* Logs show `failed to validate credentials` with that message
* **No** `requesting service-account access token` log (credentials are not POSTed to the attacker URL)

### Scenario 2: Allow validation — on-prem `api_url` + custom HTTPS token endpoint

Patch the same CR:

```yaml
spec:
  api_url: https://on-prem-koku.example.com:8443
  authentication:
    type: service-account
    secret_name: cost7999-sa-auth
    token_url: https://keycloak.example.com/auth/realms/cost/protocol/openid-connect/token
  upload:
    upload_toggle: true
```

**Expect:**

* Error is **not** the RH allowlist message
* Logs show `requesting service-account access token`, then a network/DNS failure to the custom host  
  (proves URL validation passed; token exchange was attempted)

### Scenario 3: Allow validation — RH `api_url` + SSO `token_url`

```yaml
spec:
  api_url: https://console.redhat.com
  authentication:
    type: service-account
    secret_name: cost7999-sa-auth
    token_url: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
  upload:
    upload_toggle: true
```

**Expect:**

* Validation passes; operator POSTs to `sso.redhat.com`
* With dummy secret: `failed to obtain service-account token` / `401 invalid_client` (SSO reached)
* With real service-account credentials: token exchange succeeds

### Scenario 4: Regression notes

* `upload_toggle: false` skips `setAuthAndUpload` (restricted-network path) — do not use it to test auth
* Omitting `token_url` still defaults to the prod SSO URL when using service-account auth

## Summary by Sourcery

Validate service-account token URLs before attempting token exchange and update tests to cover the new validation behavior.

New Features:
- Add runtime validation of service-account token_url to ensure HTTPS and restrict Red Hat endpoints to the official SSO token URL.

Bug Fixes:
- Prevent service-account credentials from being posted to non-HTTPS or non-approved token endpoints when using Red Hat Cost Management APIs.

Enhancements:
- Extend controller tests to verify token_url validation behavior and ensure bearer tokens are not set when validation fails.
- Adjust test configuration to use TLS-backed mock servers and disable certificate validation where needed for compatibility with the new HTTPS requirement.

Tests:
- Add table-driven unit tests for token_url validation across Red Hat and custom API scenarios, including malformed and insecure URLs.