### PR TITLE
[COST-8157] Bump ubi-micro and ubi base images (attr security fix)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,16 +27,16 @@ RUN GIT_COMMIT=$(git rev-list -1 HEAD) && \
     CGO_ENABLED=1 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} GOFLAGS=-mod=vendor \
     go build -ldflags "-w -s -X github.com/project-koku/koku-metrics-operator/internal/controller.GitCommit=$GIT_COMMIT" -a -o manager cmd/main.go
 
-FROM registry.redhat.io/ubi9/ubi-micro:9.8-1782840931 AS target-base
+FROM registry.redhat.io/ubi9/ubi-micro:9.8-1787778798 AS target-base
 
 # Prepare a ubi micro base with openssl and its dependencies.
-FROM registry.redhat.io/ubi9/ubi:9.8-1784165989 AS ubi-micro-build
+FROM registry.redhat.io/ubi9/ubi:9.8-1787634763 AS ubi-micro-build
 COPY --from=target-base / /mnt/rootfs
 RUN rpm --root /mnt/rootfs --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 RUN yum install --installroot /mnt/rootfs --releasever 9 --setopt install_weak_deps=false --setopt reposdir=/etc/yum.repos.d --nodocs -y coreutils-single glibc-minimal-langpack openssl; yum clean all
 RUN rm -rf /mnt/rootfs/var/cache/*
 
-FROM registry.redhat.io/ubi9/ubi-micro:9.8-1782840931 AS ubi9-micro
+FROM registry.redhat.io/ubi9/ubi-micro:9.8-1787778798 AS ubi9-micro
 COPY --from=ubi-micro-build /mnt/rootfs/ /
 
 WORKDIR /


### PR DESCRIPTION
## Summary

- Bump `ubi-micro` from `9.8-1782840931` to `9.8-1787778798` (built 2026-08-26)
- Bump `ubi` build stage from `9.8-1784165989` to `9.8-1787634763`

## Context

https://redhat.atlassian.net/browse/COST-8157

The `attr` package is not pinned in `rpms.lock.yaml`; it comes from the `ubi-micro` base image layer. The target `ubi-micro` image was verified via Red Hat Container Catalog to include `libattr-2.6.0-1.el9_8`.

