### PR TITLE
[COST-7814] Add NetworkPolicy RBAC for Conforma EC compliance

### DIFF
--- a/bundle/manifests/koku-metrics-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/koku-metrics-operator.clusterserviceversion.yaml
@@ -523,6 +523,15 @@ spec:
                 - create
                 - get
                 - update
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - create
+                - delete
+                - patch
+                - update
           serviceAccountName: koku-metrics-controller-manager
       deployments:
         - label:

--- a/bundle/manifests/koku-metrics-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/koku-metrics-operator.clusterserviceversion.yaml
@@ -523,15 +523,6 @@ spec:
                 - create
                 - get
                 - update
-            - apiGroups:
-                - networking.k8s.io
-              resources:
-                - networkpolicies
-              verbs:
-                - create
-                - delete
-                - patch
-                - update
           serviceAccountName: koku-metrics-controller-manager
       deployments:
         - label:
@@ -724,6 +715,15 @@ spec:
                 - patch
                 - update
                 - watch
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - create
+                - delete
+                - patch
+                - update
           serviceAccountName: koku-metrics-controller-manager
     strategy: deployment
   installModes:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -35,15 +35,6 @@ rules:
   - create
   - get
   - update
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - create
-  - delete
-  - patch
-  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -98,6 +89,15 @@ rules:
   - costmanagementmetricsconfigs/status
   verbs:
   - get
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
   - patch
   - update
 - apiGroups:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -35,6 +35,15 @@ rules:
   - create
   - get
   - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - patch
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/internal/controller/costmanagementmetricsconfig_controller.go
+++ b/internal/controller/costmanagementmetricsconfig_controller.go
@@ -812,7 +812,7 @@ func (r *MetricsConfigReconciler) setAuthAndUpload(ctx context.Context, cr *metr
 // +kubebuilder:rbac:groups=core,namespace=koku-metrics-operator,resources=pods;services;services/finalizers;endpoints;persistentvolumeclaims;events;configmaps;secrets;serviceaccounts,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=apps,namespace=koku-metrics-operator,resources=deployments,verbs=get;list;patch;watch
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheuses/api,verbs=get;create;update
-// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;patch;update
+// +kubebuilder:rbac:groups=networking.k8s.io,namespace=koku-metrics-operator,resources=networkpolicies,verbs=create;delete;patch;update
 
 // Reconcile Process the MetricsConfig custom resource based on changes or requeue
 func (r *MetricsConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/internal/controller/costmanagementmetricsconfig_controller.go
+++ b/internal/controller/costmanagementmetricsconfig_controller.go
@@ -812,6 +812,7 @@ func (r *MetricsConfigReconciler) setAuthAndUpload(ctx context.Context, cr *metr
 // +kubebuilder:rbac:groups=core,namespace=koku-metrics-operator,resources=pods;services;services/finalizers;endpoints;persistentvolumeclaims;events;configmaps;secrets;serviceaccounts,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=apps,namespace=koku-metrics-operator,resources=deployments,verbs=get;list;patch;watch
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheuses/api,verbs=get;create;update
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;patch;update
 
 // Reconcile Process the MetricsConfig custom resource based on changes or requeue
 func (r *MetricsConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
## Summary

Adds `networking.k8s.io/networkpolicies` RBAC (`create`, `delete`, `patch`, `update`) required by Konflux Enterprise Contract rule `olm.required_network_policy_rbac_for_operands` (effective 2026-08-07).

This unblocks the downstream v4.5.0 port PR (#1070), which currently fails EC on the bundle check.

Changes:
- kubebuilder RBAC marker on the reconciler
- regenerated `config/rbac/role.yaml`
- updated upstream bundle CSV `clusterPermissions`

## Test plan

- [x] `make fmt && make test`
- [x] `make verify-manifests`

## Follow-up

After merge to `main`, cherry-pick/merge into `downstream-updates-v4.5.0` and run `make manifests` (or regenerate downstream bundle) before re-running Konflux EC on PR #1070.

https://redhat.atlassian.net/browse/COST-7814



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The operator can now create, update, patch, and delete Kubernetes network policies.
  - This enables automated management of network access rules as part of the operator’s workflows.

- **Bug Fixes**
  - Updated permissions ensure network policy operations can complete successfully without authorization errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->